### PR TITLE
fix(release): trigger release workflow only on merged release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
 name: Release
 
 on:
-  push:
+  pull_request:
     branches:
       - main
-      - master
+    types:
+      - closed
 
 permissions:
   contents: write
@@ -13,6 +14,7 @@ permissions:
 jobs:
   release:
     name: Release
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository


### PR DESCRIPTION
# Changes to Release Workflow

## What's Changed
- Modified release workflow to trigger only when release PRs are merged to main
- Changed trigger from `push` to `pull_request` with `closed` type
- Added condition to check if PR is merged and branch name starts with 'release/'

## Why
This change makes the release process more controlled by:
1. Only running releases when PRs are explicitly merged (not direct pushes)
2. Only processing PRs from release branches
3. Preventing accidental releases from other branches

## Testing
- [ ] Verify release workflow triggers on merged release/* PRs
- [ ] Verify workflow doesn't trigger on non-release PRs
- [ ] Verify workflow doesn't trigger on direct pushes to main