### PR TITLE
feat: add args/kwargs support to get_injected_obj and improve type hints 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "except RuntimeError:",
     "def set_original_func",
+    "@overload",
 ]
 omit = ["example/*"]
 

--- a/src/fastapi_injectable/decorator.py
+++ b/src/fastapi_injectable/decorator.py
@@ -1,7 +1,7 @@
 import inspect
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Awaitable, Callable, Coroutine, Generator
 from functools import wraps
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast, overload
 
 from .concurrency import run_coroutine_sync
 from .main import resolve_dependencies
@@ -17,6 +17,32 @@ else:
 
     def set_original_func(wrapper: Any, target: Any) -> None:  # noqa: ANN401
         wrapper.__original_func__ = target
+
+
+@overload
+def injectable(
+    func: Callable[P, T],
+    *,
+    use_cache: bool = True,
+    raise_exception: bool = False,
+) -> Callable[P, T]: ...
+
+
+@overload
+def injectable(
+    func: Callable[P, Generator[T, Any, Any]],
+    *,
+    use_cache: bool = True,
+    raise_exception: bool = False,
+) -> Callable[P, T]: ...
+
+
+@overload
+def injectable(
+    *,
+    use_cache: bool = True,
+    raise_exception: bool = False,
+) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
 
 
 def injectable(

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -53,7 +53,7 @@ def test_sync_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_all_
         yield capital
         capital.cleanup()
 
-    @injectable(use_cache=False)  # type: ignore[arg-type]
+    @injectable(use_cache=False)
     def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
@@ -90,7 +90,7 @@ async def test_async_generators_with_injectable_be_correctly_cleaned_up_by_clean
         yield capital
         capital.cleanup()
 
-    @injectable(use_cache=False)  # type: ignore[arg-type]
+    @injectable(use_cache=False)
     async def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
@@ -127,7 +127,7 @@ async def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up
         yield capital
         capital.cleanup()
 
-    @injectable(use_cache=False)  # type: ignore[arg-type]
+    @injectable(use_cache=False)
     async def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
@@ -203,11 +203,11 @@ async def test_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by
     async def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
-    country_1: Country = get_injected_obj(get_country, use_cache=False)  # type: ignore  # noqa: PGH003
+    country_1: Country = get_injected_obj(get_country, use_cache=False)
     assert country_1.capital._is_cleaned_up is False
     assert country_1.capital.mayor._is_cleaned_up is False
 
-    country_2: Country = get_injected_obj(get_country, use_cache=False)  # type: ignore  # noqa: PGH003
+    country_2: Country = get_injected_obj(get_country, use_cache=False)
     assert country_2.capital._is_cleaned_up is False
     assert country_2.capital.mayor._is_cleaned_up is False
 
@@ -239,11 +239,11 @@ async def test_sync_and_async_generators_with_get_injected_obj_be_correctly_clea
     async def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
-    country_1: Country = get_injected_obj(get_country, use_cache=False)  # type: ignore  # noqa: PGH003
+    country_1: Country = get_injected_obj(get_country, use_cache=False)
     assert country_1.capital._is_cleaned_up is False
     assert country_1.capital.mayor._is_cleaned_up is False
 
-    country_2: Country = get_injected_obj(get_country, use_cache=False)  # type: ignore  # noqa: PGH003
+    country_2: Country = get_injected_obj(get_country, use_cache=False)
     assert country_2.capital._is_cleaned_up is False
     assert country_2.capital.mayor._is_cleaned_up is False
 
@@ -272,11 +272,11 @@ def test_sync_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_exit
         yield capital
         capital.cleanup()
 
-    @injectable(use_cache=False)  # type: ignore[arg-type]
+    @injectable(use_cache=False)
     def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
-    @injectable(use_cache=False)  # type: ignore[arg-type]
+    @injectable(use_cache=False)
     def another_get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
@@ -296,7 +296,7 @@ def test_sync_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_exit
     assert country_1.capital is not country_2.capital is not another_country_1.capital
     assert country_1.capital.mayor is not country_2.capital.mayor is not another_country_1.capital.mayor
 
-    run_coroutine_sync(cleanup_exit_stack_of_func(get_country))  # type: ignore  # noqa: PGH003
+    run_coroutine_sync(cleanup_exit_stack_of_func(get_country))
 
     assert country_1.capital._is_cleaned_up is True
     assert country_1.capital.mayor._is_cleaned_up is True  # type: ignore[unreachable]
@@ -326,11 +326,11 @@ async def test_async_generators_with_injectable_be_correctly_cleaned_up_by_clean
         yield capital
         capital.cleanup()
 
-    @injectable(use_cache=False)  # type: ignore[arg-type]
+    @injectable(use_cache=False)
     async def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
-    @injectable(use_cache=False)  # type: ignore[arg-type]
+    @injectable(use_cache=False)
     def another_get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
@@ -350,7 +350,7 @@ async def test_async_generators_with_injectable_be_correctly_cleaned_up_by_clean
     assert country_1.capital is not country_2.capital is not another_country_1.capital
     assert country_1.capital.mayor is not country_2.capital.mayor is not another_country_1.capital.mayor
 
-    await cleanup_exit_stack_of_func(get_country)  # type: ignore  # noqa: PGH003
+    await cleanup_exit_stack_of_func(get_country)
 
     assert country_1.capital._is_cleaned_up is True
     assert country_1.capital.mayor._is_cleaned_up is True  # type: ignore[unreachable]
@@ -380,11 +380,11 @@ async def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up
         yield capital
         capital.cleanup()
 
-    @injectable(use_cache=False)  # type: ignore[arg-type]
+    @injectable(use_cache=False)
     async def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
-    @injectable(use_cache=False)  # type: ignore[arg-type]
+    @injectable(use_cache=False)
     def another_get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
@@ -404,7 +404,7 @@ async def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up
     assert country_1.capital is not country_2.capital
     assert country_1.capital.mayor is not country_2.capital.mayor
 
-    await cleanup_exit_stack_of_func(get_country)  # type: ignore  # noqa: PGH003
+    await cleanup_exit_stack_of_func(get_country)
 
     assert country_1.capital._is_cleaned_up is True
     assert country_1.capital.mayor._is_cleaned_up is True  # type: ignore[unreachable]
@@ -492,11 +492,11 @@ async def test_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by
     def another_get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
-    country_1: Country = get_injected_obj(get_country, use_cache=False)  # type: ignore  # noqa: PGH003
+    country_1: Country = get_injected_obj(get_country, use_cache=False)
     assert country_1.capital._is_cleaned_up is False
     assert country_1.capital.mayor._is_cleaned_up is False
 
-    country_2: Country = get_injected_obj(get_country, use_cache=False)  # type: ignore  # noqa: PGH003
+    country_2: Country = get_injected_obj(get_country, use_cache=False)
     assert country_2.capital._is_cleaned_up is False
     assert country_2.capital.mayor._is_cleaned_up is False
 
@@ -544,11 +544,11 @@ async def test_sync_and_async_generators_with_get_injected_obj_be_correctly_clea
     def another_get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
-    country_1: Country = get_injected_obj(get_country, use_cache=False)  # type: ignore  # noqa: PGH003
+    country_1: Country = get_injected_obj(get_country, use_cache=False)
     assert country_1.capital._is_cleaned_up is False
     assert country_1.capital.mayor._is_cleaned_up is False
 
-    country_2: Country = get_injected_obj(get_country, use_cache=False)  # type: ignore  # noqa: PGH003
+    country_2: Country = get_injected_obj(get_country, use_cache=False)
     assert country_2.capital._is_cleaned_up is False
     assert country_2.capital.mayor._is_cleaned_up is False
 


### PR DESCRIPTION
# Add args/kwargs support to get_injected_obj and improve type hints

## Changes

### Added
- `py.typed` file suggested by @machinehead (https://github.com/JasperSui/fastapi-injectable/issues/44)
- Support for passing positional and keyword arguments to `get_injected_obj`
- `@overload` type hints for `injectable` decorator and `get_injected_obj` 
- Comprehensive test cases for args/kwargs functionality
- Added `@overload` to coverage exclusions in pyproject.toml

### Fixed
- Improved type hints throughout the codebase
- Removed unnecessary type ignores in tests
- Fixed type casting in `get_injected_obj` implementation

## Testing
- Added new test cases covering:
  - Basic args/kwargs usage
  - Args/kwargs with sync functions
  - Args/kwargs with async functions
  - Args/kwargs with sync/async generators
  - Combined args and kwargs usage

## Impact
This change improves the API's flexibility by allowing argument passing to injected dependencies while maintaining type safety. The improved type hints provide better IDE support and catch potential type errors at compile time.