### PR TITLE
refactor(dependencies): ignore FastAPI route-specific errors during dependency resolution

### DIFF
--- a/src/fastapi_injectable/__init__.py
+++ b/src/fastapi_injectable/__init__.py
@@ -1,5 +1,4 @@
 from .decorator import injectable
-from .exception import DependencyResolveError
 from .main import register_app, resolve_dependencies
 from .util import (
     cleanup_all_exit_stacks,
@@ -10,7 +9,6 @@ from .util import (
 )
 
 __all__ = [
-    "DependencyResolveError",
     "cleanup_all_exit_stacks",
     "cleanup_exit_stack_of_func",
     "clear_dependency_cache",

--- a/src/fastapi_injectable/decorator.py
+++ b/src/fastapi_injectable/decorator.py
@@ -24,7 +24,6 @@ def injectable(
     func: Callable[P, T],
     *,
     use_cache: bool = True,
-    raise_exception: bool = False,
 ) -> Callable[P, T]: ...
 
 
@@ -33,7 +32,6 @@ def injectable(
     func: Callable[P, Generator[T, Any, Any]],
     *,
     use_cache: bool = True,
-    raise_exception: bool = False,
 ) -> Callable[P, T]: ...
 
 
@@ -41,7 +39,6 @@ def injectable(
 def injectable(
     *,
     use_cache: bool = True,
-    raise_exception: bool = False,
 ) -> Callable[[Callable[P, T]], Callable[P, T]]: ...
 
 
@@ -49,7 +46,6 @@ def injectable(
     func: Callable[P, T] | Callable[P, Awaitable[T]] | None = None,
     *,
     use_cache: bool = True,
-    raise_exception: bool = False,
 ) -> (
     Callable[P, T]
     | Callable[P, Awaitable[T]]
@@ -64,14 +60,12 @@ def injectable(
 
         @wraps(target)
         async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-            dependencies = await resolve_dependencies(func=target, use_cache=use_cache, raise_exception=raise_exception)
+            dependencies = await resolve_dependencies(func=target, use_cache=use_cache)
             return await cast(Callable[..., Coroutine[Any, Any, T]], target)(*args, **{**dependencies, **kwargs})
 
         @wraps(target)
         def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-            dependencies = run_coroutine_sync(
-                resolve_dependencies(func=target, use_cache=use_cache, raise_exception=raise_exception)
-            )
+            dependencies = run_coroutine_sync(resolve_dependencies(func=target, use_cache=use_cache))
             return cast(Callable[..., T], target)(*args, **{**dependencies, **kwargs})
 
         if is_async:

--- a/src/fastapi_injectable/exception.py
+++ b/src/fastapi_injectable/exception.py
@@ -1,7 +1,3 @@
-class DependencyResolveError(Exception):
-    """Custom error for dependency resolve issues."""
-
-
 class DependencyCleanupError(Exception):
     """Custom error for dependency cleanup issues."""
 

--- a/src/fastapi_injectable/util.py
+++ b/src/fastapi_injectable/util.py
@@ -20,7 +20,6 @@ def get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
-    raise_exception: bool = False,
 ) -> T: ...
 
 
@@ -31,7 +30,6 @@ def get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
-    raise_exception: bool = False,
 ) -> T: ...
 
 
@@ -42,7 +40,6 @@ def get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
-    raise_exception: bool = False,
 ) -> T: ...
 
 
@@ -53,7 +50,6 @@ def get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
-    raise_exception: bool = False,
 ) -> T: ...
 
 
@@ -68,7 +64,6 @@ def get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
-    raise_exception: bool = False,
 ) -> T:
     """Get an injected object from a dependency function with FastAPI's dependency injection.
 
@@ -84,8 +79,6 @@ def get_injected_obj(
         args: Positional arguments to pass to the dependency function.
         kwargs: Keyword arguments to pass to the dependency function.
         use_cache: Whether to cache resolved dependencies. Defaults to True.
-        raise_exception: Whether to raise exceptions during dependency resolution.
-            If False, exceptions are logged as warnings. Defaults to False.
 
     Returns:
         The first value yielded/returned by the dependency function after injection.
@@ -118,7 +111,7 @@ def get_injected_obj(
         - Cleanup code in generators will be executed when calling cleanup functions
         - Uses FastAPI's dependency injection system under the hood
     """
-    injectable_func = injectable(func, use_cache=use_cache, raise_exception=raise_exception)
+    injectable_func = injectable(func, use_cache=use_cache)
 
     if args is None:
         args = []

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -59,7 +59,7 @@ def test_get_injected_obj_sync(mock_injectable: Mock, mock_run_coroutine_sync: M
     mock_injectable.return_value = lambda: DummyDependency()
     result = get_injected_obj(dummy_get_dependency)
 
-    mock_injectable.assert_called_once_with(dummy_get_dependency, use_cache=True, raise_exception=False)
+    mock_injectable.assert_called_once_with(dummy_get_dependency, use_cache=True)
     assert isinstance(result, DummyDependency)
     mock_run_coroutine_sync.assert_not_called()
 
@@ -70,7 +70,7 @@ def test_get_injected_obj_async(mock_injectable: Mock, mock_run_coroutine_sync: 
 
     result: DummyDependency = get_injected_obj(dummy_async_get_dependency)
 
-    mock_injectable.assert_called_once_with(dummy_async_get_dependency, use_cache=True, raise_exception=False)
+    mock_injectable.assert_called_once_with(dummy_async_get_dependency, use_cache=True)
     assert isinstance(result, DummyDependency)
     mock_run_coroutine_sync.assert_called_once()
 
@@ -84,7 +84,7 @@ async def test_get_injected_obj_async_generator(mock_injectable: Mock, mock_run_
 
     result: DummyDependency = get_injected_obj(dummy_async_gen_dependency)
 
-    mock_injectable.assert_called_once_with(dummy_async_gen_dependency, use_cache=True, raise_exception=False)
+    mock_injectable.assert_called_once_with(dummy_async_gen_dependency, use_cache=True)
     assert isinstance(result, DummyDependency)
     mock_run_coroutine_sync.assert_called_once()
 
@@ -96,7 +96,7 @@ def test_get_injected_obj_sync_generator(mock_injectable: Mock, mock_run_corouti
     mock_injectable.return_value = lambda: dummy_gen_dependency()
     result: DummyDependency = get_injected_obj(dummy_gen_dependency)
 
-    mock_injectable.assert_called_once_with(dummy_gen_dependency, use_cache=True, raise_exception=False)
+    mock_injectable.assert_called_once_with(dummy_gen_dependency, use_cache=True)
     assert isinstance(result, DummyDependency)
     mock_run_coroutine_sync.assert_not_called()
 
@@ -105,7 +105,7 @@ def test_get_injected_obj_with_args(mock_injectable: Mock, mock_run_coroutine_sy
     mock_injectable.return_value = lambda *args, **kwargs: DummyDependency(*args, **kwargs)
     result = get_injected_obj(dummy_get_dependency, args=[42, "test"])
 
-    mock_injectable.assert_called_once_with(dummy_get_dependency, use_cache=True, raise_exception=False)
+    mock_injectable.assert_called_once_with(dummy_get_dependency, use_cache=True)
     assert result.attr_1 == 42
     assert result.attr_2 == "test"
     mock_run_coroutine_sync.assert_not_called()
@@ -115,7 +115,7 @@ def test_get_injected_obj_with_kwargs(mock_injectable: Mock, mock_run_coroutine_
     mock_injectable.return_value = lambda *args, **kwargs: DummyDependency(*args, **kwargs)
     result = get_injected_obj(dummy_get_dependency, kwargs={"attr_1": 42, "attr_2": "test"})
 
-    mock_injectable.assert_called_once_with(dummy_get_dependency, use_cache=True, raise_exception=False)
+    mock_injectable.assert_called_once_with(dummy_get_dependency, use_cache=True)
     assert result.attr_1 == 42
     assert result.attr_2 == "test"
     mock_run_coroutine_sync.assert_not_called()
@@ -125,7 +125,7 @@ def test_get_injected_obj_with_args_and_kwargs(mock_injectable: Mock, mock_run_c
     mock_injectable.return_value = lambda *args, **kwargs: DummyDependency(*args, **kwargs)
     result = get_injected_obj(dummy_get_dependency, args=[42], kwargs={"attr_2": "test"})
 
-    mock_injectable.assert_called_once_with(dummy_get_dependency, use_cache=True, raise_exception=False)
+    mock_injectable.assert_called_once_with(dummy_get_dependency, use_cache=True)
     assert result.attr_1 == 42
     assert result.attr_2 == "test"
     mock_run_coroutine_sync.assert_not_called()
@@ -137,7 +137,7 @@ async def test_get_injected_obj_async_with_args_kwargs(mock_injectable: Mock, mo
 
     result = get_injected_obj(dummy_async_get_dependency, args=[42], kwargs={"attr_2": "test"})
 
-    mock_injectable.assert_called_once_with(dummy_async_get_dependency, use_cache=True, raise_exception=False)
+    mock_injectable.assert_called_once_with(dummy_async_get_dependency, use_cache=True)
     assert result.attr_1 == 42
     assert result.attr_2 == "test"
     mock_run_coroutine_sync.assert_called_once()
@@ -150,7 +150,7 @@ def test_get_injected_obj_sync_generator_with_args_kwargs(mock_injectable: Mock,
     mock_injectable.return_value = lambda *args, **kwargs: dummy_gen_with_args(*args, **kwargs)
     result = get_injected_obj(dummy_gen_with_args, args=[42], kwargs={"attr_2": "test"})
 
-    mock_injectable.assert_called_once_with(dummy_gen_with_args, use_cache=True, raise_exception=False)
+    mock_injectable.assert_called_once_with(dummy_gen_with_args, use_cache=True)
     assert result.attr_1 == 42
     assert result.attr_2 == "test"
     mock_run_coroutine_sync.assert_not_called()
@@ -167,7 +167,7 @@ async def test_get_injected_obj_async_generator_with_args_kwargs(
 
     result = get_injected_obj(dummy_async_gen_with_args, args=[42], kwargs={"attr_2": "test"})
 
-    mock_injectable.assert_called_once_with(dummy_async_gen_with_args, use_cache=True, raise_exception=False)
+    mock_injectable.assert_called_once_with(dummy_async_gen_with_args, use_cache=True)
     assert result.attr_1 == 42
     assert result.attr_2 == "test"
     mock_run_coroutine_sync.assert_called_once()


### PR DESCRIPTION
# Purpose
To improve the accuracy and simplicity of the dependency resolution system by ignoring FastAPI route-specific errors that aren't relevant when resolving `Depends()` parameters.

Related to https://github.com/JasperSui/fastapi-injectable/issues/74

# Changes

### TL;DR
Removed error handling intended for FastAPI routes, simplified the API by removing the `raise_exception` parameter, and improved dependency resolution by filtering to include only actual dependency parameters.

---

### BREAKING CHANGES:
- Remove `DependencyResolveError` exception class
- Remove `raise_exception` parameter from `injectable`, `resolve_dependencies`, and `get_injected_obj`

### Others
- Filter resolved dependencies to only include actual dependency parameters
- Add test for function with non-dependency parameters and dependencies



The `solve_dependencies.errors` are intended for FastAPI routes only, not for actual errors when resolving `Depends()` parameters. This change simplifies the API and removes handling of errors that aren't relevant in this context.