### PR TITLE
refactor: simplify event loop management to use application's main loop

### DIFF
--- a/src/fastapi_injectable/async_exit_stack.py
+++ b/src/fastapi_injectable/async_exit_stack.py
@@ -5,7 +5,6 @@ from contextlib import AsyncExitStack
 from typing import Any
 from weakref import WeakKeyDictionary
 
-from .concurrency import loop_manager
 from .exception import DependencyCleanupError
 
 logger = logging.getLogger(__name__)
@@ -51,7 +50,7 @@ class AsyncExitStackManager:
                 return  # pragma: no cover
 
             try:
-                await loop_manager.run_in_loop(stack.aclose())
+                await stack.aclose()
             except Exception as e:  # pragma: no cover
                 msg = f"Failed to cleanup stack for {func.__name__}"
                 if raise_exception:
@@ -78,7 +77,7 @@ class AsyncExitStackManager:
                 return  # pragma: no cover
 
             try:
-                await loop_manager.run_in_loop(asyncio.gather(*tasks))
+                await asyncio.gather(*tasks)
             except Exception as e:  # pragma: no cover
                 msg = "Failed to cleanup one or more dependency stacks"
                 if raise_exception:

--- a/src/fastapi_injectable/concurrency.py
+++ b/src/fastapi_injectable/concurrency.py
@@ -1,106 +1,26 @@
 import asyncio
-import atexit
-import threading
 from collections.abc import Coroutine
 from typing import Any, TypeVar
-
-from fastapi_injectable.exception import RunCoroutineSyncMaxRetriesError
 
 T = TypeVar("T")
 
 
-class LoopManager:
-    def __init__(self) -> None:
-        self._loop: asyncio.AbstractEventLoop | None = None
-        self._thread: threading.Thread | None = None
-        self._lock = threading.Lock()
-        self._shutting_down = False
-
-    def get_loop(self) -> asyncio.AbstractEventLoop:
-        with self._lock:
-            if self._loop is None or self._loop.is_closed():
-                self.start()
-            assert self._loop is not None  # noqa: S101
-            return self._loop
-
-    def start(self) -> None:
-        self._loop = asyncio.new_event_loop()
-        self._thread = threading.Thread(target=self._run_loop, daemon=True, name="async-util-loop")
-        self._thread.start()
-
-    async def run_in_loop(self, coro: Coroutine[Any, Any, T] | asyncio.Future[T]) -> T:
-        """Run coroutine in the managed loop.
-
-        Args:
-            coro: Coroutine to run
-
-        Returns:
-            Result of the coroutine
-        """
-        current_loop = asyncio.get_event_loop()
-        loop = self.get_loop()
-        try:
-            asyncio.set_event_loop(loop)
-            return await coro
-        finally:
-            asyncio.set_event_loop(current_loop)
-
-    def _run_loop(self) -> None:
-        assert self._loop is not None  # noqa: S101
-        asyncio.set_event_loop(self._loop)
-        try:
-            self._loop.run_forever()
-        finally:
-            if not self._shutting_down:
-                self._loop.close()
-
-    def shutdown(self) -> None:
-        with self._lock:
-            self._shutting_down = True
-            if self._loop and self._loop.is_running():
-                self._loop.call_soon_threadsafe(self._loop.stop)
-            if self._thread:
-                self._thread.join(timeout=1)
-            if self._loop and not self._loop.is_closed():
-                self._loop.close()
-
-
-loop_manager = LoopManager()
-atexit.register(loop_manager.shutdown)
-
-
-def run_coroutine_sync(
-    coro: Coroutine[Any, Any, T], *, timeout: float = 30, retries: int = 1, max_retries: int = 5
-) -> T:
-    """Synchronously run an async coroutine, with support for both main and non-main threads.
+def run_coroutine_sync(coro: Coroutine[Any, Any, T]) -> T:
+    """Run an async coroutine synchronously.
 
     Args:
         coro: The coroutine to execute.
-        timeout: Timeout for execution when running in a thread pool.
-        retries: Number of retries to run the coroutine.
-        max_retries: Maximum number of retries.
 
     Returns:
         The result of the coroutine execution.
 
     Raises:
         Any exception raised by the coroutine or during execution.
-
-    Notes:
-        - In the main thread, if the event loop is running, a new thread is used to run the coroutine.
-        - In non-main threads, asyncio's `run_coroutine_threadsafe` is used for compatibility.
     """
-    if retries > max_retries:
-        msg = f"Maximum retries ({max_retries}) reached while running coroutine."
-        raise RunCoroutineSyncMaxRetriesError(msg)
-
     try:
-        loop = loop_manager.get_loop()
-        future = asyncio.run_coroutine_threadsafe(coro, loop)
-        return future.result(timeout)
+        loop = asyncio.get_event_loop()
     except RuntimeError as e:
-        if "Event loop is closed" in str(e):
-            loop_manager.shutdown()
-            loop_manager.start()
-            return run_coroutine_sync(coro, timeout=timeout, retries=retries + 1, max_retries=max_retries)
-        raise
+        msg = "Failed to get a runnable event loop"
+        raise RuntimeError(msg) from e
+
+    return loop.run_until_complete(coro)

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -1,114 +1,21 @@
-import asyncio
-import threading
-import time
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import patch
 
 import pytest
 
-from fastapi_injectable.exception import RunCoroutineSyncMaxRetriesError
-from src.fastapi_injectable.concurrency import LoopManager, run_coroutine_sync
+from src.fastapi_injectable.concurrency import run_coroutine_sync
 
 
-async def test_loop_manager_shutdown() -> None:
-    manager = LoopManager()
-    manager.start()
+def test_run_coroutine_sync_success() -> None:
+    async def coro() -> str:
+        return "test"
 
-    # Mock the loop and thread
-    mock_loop = Mock()
-    mock_loop.is_running.return_value = True
-    mock_loop.is_closed.return_value = False
-    manager._loop = mock_loop
-
-    # Create and start a dummy thread
-    mock_thread = threading.Thread(target=lambda: None)
-    mock_thread.start()
-    manager._thread = mock_thread
-
-    # Test shutdown
-    manager.shutdown()
-
-    assert manager._shutting_down is True
-    mock_loop.call_soon_threadsafe.assert_called_once_with(mock_loop.stop)
-    mock_loop.close.assert_called_once()
+    assert run_coroutine_sync(coro()) == "test"
 
 
-def test_loop_closes_when_not_shutting_down() -> None:
-    manager = LoopManager()
+def test_run_coroutine_sync_failed_to_get_event_loop() -> None:
+    async def coro() -> str:
+        return "test"
 
-    # Mock the loop to track close() calls
-    mock_loop = MagicMock(spec=asyncio.AbstractEventLoop)
-    mock_loop.is_running.return_value = False
-    mock_loop.is_closed.return_value = False
-
-    with patch("asyncio.new_event_loop", return_value=mock_loop):
-        manager.start()
-        # Give the thread a moment to start
-        time.sleep(0.1)
-        # Force the loop to stop
-        mock_loop.run_forever.side_effect = Exception("Force stop")
-
-        # Wait for thread to finish
-        assert isinstance(manager._thread, threading.Thread)
-        manager._thread.join(timeout=1)
-
-        # Verify loop.close() was called since _shutting_down is False
-        mock_loop.close.assert_called_once()
-
-
-async def test_loop_manager_shutdown_no_running_loop() -> None:
-    manager = LoopManager()
-    manager.start()
-
-    # Mock the loop that's not running
-    mock_loop = Mock()
-    mock_loop.is_running.return_value = False
-    mock_loop.is_closed.return_value = False
-    manager._loop = mock_loop
-
-    # Test shutdown
-    manager.shutdown()
-
-    assert manager._shutting_down is True
-    mock_loop.call_soon_threadsafe.assert_not_called()
-    mock_loop.close.assert_called_once()
-
-
-def test_loop_manager_shutdown_with_no_thread_or_loop() -> None:
-    manager = LoopManager()
-    manager.shutdown()  # Should not raise any errors
-
-
-def test_loop_manager_shutdown_with_running_loop_no_thread() -> None:
-    manager = LoopManager()
-    manager._loop = Mock()
-
-    manager._loop.is_running.return_value = True
-    manager._loop.is_closed.return_value = False
-    manager.shutdown()
-
-    assert manager._shutting_down is True
-    manager._loop.close.assert_called_once()
-
-
-@patch("fastapi_injectable.concurrency.asyncio.run_coroutine_threadsafe")
-async def test_run_coroutine_sync_max_retries(mock_run_coroutine_threadsafe: Mock) -> None:
-    # Mock coroutine that creates a new coroutine each time
-    async def mock_coro() -> None:
-        pass
-
-    # Make run_coroutine_threadsafe always raise RuntimeError
-    mock_run_coroutine_threadsafe.side_effect = RuntimeError("Event loop is closed")
-
-    # Test max retries exceeded
-    with pytest.raises(RunCoroutineSyncMaxRetriesError, match="Maximum retries .* reached"):
-        run_coroutine_sync(mock_coro(), max_retries=2)
-
-
-async def test_run_coroutine_sync_other_runtime_error() -> None:
-    async def mock_coro() -> None:
-        msg = "Some other error"
-        raise RuntimeError(msg)
-
-    # Test that other RuntimeErrors are re-raised
-    with pytest.raises(RuntimeError, match="Some other error"):
-        run_coroutine_sync(mock_coro())
+    with patch("asyncio.get_event_loop", side_effect=RuntimeError("No running event loop")):  # noqa: SIM117
+        with pytest.raises(RuntimeError, match="Failed to get a runnable event loop"):
+            run_coroutine_sync(coro())

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -77,7 +77,7 @@ def test_sync_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_all_
     assert country_2.capital.mayor._is_cleaned_up is True
 
 
-async def test_async_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_all_exit_stacks(
+def test_async_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_all_exit_stacks(
     clean_exit_stack_manager: None,
 ) -> None:
     async def get_mayor() -> AsyncGenerator[Mayor, None]:
@@ -94,11 +94,11 @@ async def test_async_generators_with_injectable_be_correctly_cleaned_up_by_clean
     async def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
-    country_1: Country = await get_country()  # type: ignore  # noqa: PGH003
+    country_1: Country = run_coroutine_sync(get_country())  # type: ignore  # noqa: PGH003
     assert country_1.capital._is_cleaned_up is False
     assert country_1.capital.mayor._is_cleaned_up is False
 
-    country_2: Country = await get_country()  # type: ignore  # noqa: PGH003
+    country_2: Country = run_coroutine_sync(get_country())  # type: ignore  # noqa: PGH003
     assert country_2.capital._is_cleaned_up is False
     assert country_2.capital.mayor._is_cleaned_up is False
 
@@ -106,7 +106,7 @@ async def test_async_generators_with_injectable_be_correctly_cleaned_up_by_clean
     assert country_1.capital is not country_2.capital
     assert country_1.capital.mayor is not country_2.capital.mayor
 
-    await cleanup_all_exit_stacks()
+    run_coroutine_sync(cleanup_all_exit_stacks())
 
     assert country_1.capital._is_cleaned_up is True
     assert country_1.capital.mayor._is_cleaned_up is True  # type: ignore[unreachable]
@@ -114,7 +114,7 @@ async def test_async_generators_with_injectable_be_correctly_cleaned_up_by_clean
     assert country_2.capital.mayor._is_cleaned_up is True
 
 
-async def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_all_exit_stacks(
+def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_all_exit_stacks(
     clean_exit_stack_manager: None,
 ) -> None:
     def get_mayor() -> Generator[Mayor, None, None]:
@@ -131,11 +131,11 @@ async def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up
     async def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
-    country_1: Country = await get_country()  # type: ignore  # noqa: PGH003
+    country_1: Country = run_coroutine_sync(get_country())  # type: ignore  # noqa: PGH003
     assert country_1.capital._is_cleaned_up is False
     assert country_1.capital.mayor._is_cleaned_up is False
 
-    country_2: Country = await get_country()  # type: ignore  # noqa: PGH003
+    country_2: Country = run_coroutine_sync(get_country())  # type: ignore  # noqa: PGH003
     assert country_2.capital._is_cleaned_up is False
     assert country_2.capital.mayor._is_cleaned_up is False
 
@@ -143,7 +143,7 @@ async def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up
     assert country_1.capital is not country_2.capital
     assert country_1.capital.mayor is not country_2.capital.mayor
 
-    await cleanup_all_exit_stacks()
+    run_coroutine_sync(cleanup_all_exit_stacks())
 
     assert country_1.capital._is_cleaned_up is True
     assert country_1.capital.mayor._is_cleaned_up is True  # type: ignore[unreachable]
@@ -187,7 +187,7 @@ def test_sync_generators_with_get_injected_obj_be_correctly_cleaned_up_by_cleanu
     assert country_2.capital.mayor._is_cleaned_up is True
 
 
-async def test_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by_cleanup_all_exit_stacks(
+def test_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by_cleanup_all_exit_stacks(
     clean_exit_stack_manager: None,
 ) -> None:
     async def get_mayor() -> AsyncGenerator[Mayor, None]:
@@ -215,7 +215,7 @@ async def test_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by
     assert country_1.capital is not country_2.capital
     assert country_1.capital.mayor is not country_2.capital.mayor
 
-    await cleanup_all_exit_stacks()
+    run_coroutine_sync(cleanup_all_exit_stacks())
 
     assert country_1.capital._is_cleaned_up is True
     assert country_1.capital.mayor._is_cleaned_up is True  # type: ignore[unreachable]
@@ -223,7 +223,7 @@ async def test_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by
     assert country_2.capital.mayor._is_cleaned_up is True
 
 
-async def test_sync_and_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by_cleanup_all_exit_stacks(
+def test_sync_and_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by_cleanup_all_exit_stacks(
     clean_exit_stack_manager: None,
 ) -> None:
     def get_mayor() -> Generator[Mayor, None, None]:
@@ -251,7 +251,7 @@ async def test_sync_and_async_generators_with_get_injected_obj_be_correctly_clea
     assert country_1.capital is not country_2.capital
     assert country_1.capital.mayor is not country_2.capital.mayor
 
-    await cleanup_all_exit_stacks()
+    run_coroutine_sync(cleanup_all_exit_stacks())
 
     assert country_1.capital._is_cleaned_up is True
     assert country_1.capital.mayor._is_cleaned_up is True  # type: ignore[unreachable]
@@ -313,7 +313,7 @@ def test_sync_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_exit
     assert another_country_1.capital.mayor._is_cleaned_up is True
 
 
-async def test_async_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_exit_stack_of_func(
+def test_async_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_exit_stack_of_func(
     clean_exit_stack_manager: None,
 ) -> None:
     async def get_mayor() -> AsyncGenerator[Mayor, None]:
@@ -334,11 +334,11 @@ async def test_async_generators_with_injectable_be_correctly_cleaned_up_by_clean
     def another_get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
-    country_1: Country = await get_country()  # type: ignore  # noqa: PGH003
+    country_1: Country = run_coroutine_sync(get_country())  # type: ignore  # noqa: PGH003
     assert country_1.capital._is_cleaned_up is False
     assert country_1.capital.mayor._is_cleaned_up is False
 
-    country_2: Country = await get_country()  # type: ignore  # noqa: PGH003
+    country_2: Country = run_coroutine_sync(get_country())  # type: ignore  # noqa: PGH003
     assert country_2.capital._is_cleaned_up is False
     assert country_2.capital.mayor._is_cleaned_up is False
 
@@ -350,7 +350,7 @@ async def test_async_generators_with_injectable_be_correctly_cleaned_up_by_clean
     assert country_1.capital is not country_2.capital is not another_country_1.capital
     assert country_1.capital.mayor is not country_2.capital.mayor is not another_country_1.capital.mayor
 
-    await cleanup_exit_stack_of_func(get_country)
+    run_coroutine_sync(cleanup_exit_stack_of_func(get_country))
 
     assert country_1.capital._is_cleaned_up is True
     assert country_1.capital.mayor._is_cleaned_up is True  # type: ignore[unreachable]
@@ -361,13 +361,13 @@ async def test_async_generators_with_injectable_be_correctly_cleaned_up_by_clean
     assert another_country_1.capital._is_cleaned_up is False
     assert another_country_1.capital.mayor._is_cleaned_up is False
 
-    await cleanup_exit_stack_of_func(another_get_country)
+    run_coroutine_sync(cleanup_exit_stack_of_func(another_get_country))
 
     assert another_country_1.capital._is_cleaned_up is True
     assert another_country_1.capital.mayor._is_cleaned_up is True
 
 
-async def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_exit_stack_of_func(
+def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up_by_cleanup_exit_stack_of_func(
     clean_exit_stack_manager: None,
 ) -> None:
     def get_mayor() -> Generator[Mayor, None, None]:
@@ -388,11 +388,11 @@ async def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up
     def another_get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
         return Country(capital)
 
-    country_1: Country = await get_country()  # type: ignore  # noqa: PGH003
+    country_1: Country = run_coroutine_sync(get_country())  # type: ignore  # noqa: PGH003
     assert country_1.capital._is_cleaned_up is False
     assert country_1.capital.mayor._is_cleaned_up is False
 
-    country_2: Country = await get_country()  # type: ignore  # noqa: PGH003
+    country_2: Country = run_coroutine_sync(get_country())  # type: ignore  # noqa: PGH003
     assert country_2.capital._is_cleaned_up is False
     assert country_2.capital.mayor._is_cleaned_up is False
 
@@ -404,7 +404,7 @@ async def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up
     assert country_1.capital is not country_2.capital
     assert country_1.capital.mayor is not country_2.capital.mayor
 
-    await cleanup_exit_stack_of_func(get_country)
+    run_coroutine_sync(cleanup_exit_stack_of_func(get_country))
 
     assert country_1.capital._is_cleaned_up is True
     assert country_1.capital.mayor._is_cleaned_up is True  # type: ignore[unreachable]
@@ -415,7 +415,7 @@ async def test_sync_and_async_generators_with_injectable_be_correctly_cleaned_up
     assert another_country_1.capital._is_cleaned_up is False
     assert another_country_1.capital.mayor._is_cleaned_up is False
 
-    await cleanup_exit_stack_of_func(another_get_country)
+    run_coroutine_sync(cleanup_exit_stack_of_func(another_get_country))
 
     assert another_country_1.capital._is_cleaned_up is True
     assert another_country_1.capital.mayor._is_cleaned_up is True
@@ -473,7 +473,7 @@ def test_sync_generators_with_get_injected_obj_be_correctly_cleaned_up_by_cleanu
     assert another_country_1.capital.mayor._is_cleaned_up is True
 
 
-async def test_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by_cleanup_exit_stack_of_func(
+def test_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by_cleanup_exit_stack_of_func(
     clean_exit_stack_manager: None,
 ) -> None:
     async def get_mayor() -> AsyncGenerator[Mayor, None]:
@@ -508,7 +508,7 @@ async def test_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by
     assert country_1.capital is not country_2.capital is not another_country_1.capital
     assert country_1.capital.mayor is not country_2.capital.mayor is not another_country_1.capital.mayor
 
-    await cleanup_exit_stack_of_func(get_country)
+    run_coroutine_sync(cleanup_exit_stack_of_func(get_country))
 
     assert country_1.capital._is_cleaned_up is True
     assert country_1.capital.mayor._is_cleaned_up is True  # type: ignore[unreachable]
@@ -519,13 +519,13 @@ async def test_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by
     assert another_country_1.capital._is_cleaned_up is False
     assert another_country_1.capital.mayor._is_cleaned_up is False
 
-    await cleanup_exit_stack_of_func(another_get_country)
+    run_coroutine_sync(cleanup_exit_stack_of_func(another_get_country))
 
     assert another_country_1.capital._is_cleaned_up is True
     assert another_country_1.capital.mayor._is_cleaned_up is True
 
 
-async def test_sync_and_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by_cleanup_exit_stack_of_func(
+def test_sync_and_async_generators_with_get_injected_obj_be_correctly_cleaned_up_by_cleanup_exit_stack_of_func(
     clean_exit_stack_manager: None,
 ) -> None:
     def get_mayor() -> Generator[Mayor, None, None]:
@@ -560,7 +560,7 @@ async def test_sync_and_async_generators_with_get_injected_obj_be_correctly_clea
     assert country_1.capital is not country_2.capital is not another_country_1.capital
     assert country_1.capital.mayor is not country_2.capital.mayor is not another_country_1.capital.mayor
 
-    await cleanup_exit_stack_of_func(get_country)
+    run_coroutine_sync(cleanup_exit_stack_of_func(get_country))
 
     assert country_1.capital._is_cleaned_up is True
     assert country_1.capital.mayor._is_cleaned_up is True  # type: ignore[unreachable]
@@ -571,7 +571,7 @@ async def test_sync_and_async_generators_with_get_injected_obj_be_correctly_clea
     assert another_country_1.capital._is_cleaned_up is False
     assert another_country_1.capital.mayor._is_cleaned_up is False
 
-    await cleanup_exit_stack_of_func(another_get_country)
+    run_coroutine_sync(cleanup_exit_stack_of_func(another_get_country))
 
     assert another_country_1.capital._is_cleaned_up is True
     assert another_country_1.capital.mayor._is_cleaned_up is True


### PR DESCRIPTION
# Simplify event loop management to use application's main loop

## Description
This PR simplifies the library's approach to async event loop management by removing the custom daemon thread approach and relying on the application's main event loop. This is a breaking change that resolves compatibility issues with libraries like aiohttp.

### Key Changes
- Remove `LoopManager` class and daemon thread approach
- Simplify `run_coroutine_sync` to use the application's event loop
- Update `AsyncExitStackManager` to directly await coroutines without loop management
- Convert async tests to sync tests using the simplified `run_coroutine_sync`

### Benefits
- Resolves issues with libraries like aiohttp where injected objects were attached to the wrong event loop
- Simplifies stack cleanup by removing multi-loop considerations
- Makes the library more predictable by using a single event loop model
- Reduces complexity and potential threading issues

### Breaking Changes
This is a breaking change for users who relied on the library managing its own event loop. Applications will now need to ensure they have a properly configured event loop.