### PR TITLE
feat: add mypy plugin for enhanced type checking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,35 @@ assert country_1.capital is not country_2.capital is not country_3.capital
 assert country_1.capital.mayor is not country_2.capital.mayor is not country_3.capital.mayor
 ```
 
+### Type Hinting
+
+`fastapi-injectable` will prepare the dependency objects of injected functions for you, but static type checkers like `mypy` haven't known about the dependency object existence since they are normally injected via `Annotated[Type, Depends(get_dependency_func)]`, when using this kind of expression, static type checkers will complain if you don't explicitly provide the dependency object when using the function, example error codes ([call-arg](https://mypy.readthedocs.io/en/stable/error_code_list.html#check-arguments-in-calls-call-arg)).
+
+```python
+
+@injectable
+def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
+    return Country(capital)
+
+country = get_country() # mypy will complain here, error: Missing positional arguments or Too few arguments.
+```
+
+To make the `mypy` happy, you can enable the `fastapi-injectable.mypy` plugin in your `mypy.ini` file, or add `fastapi_injectable.mypy` to your `pyproject.toml` file.
+
+```toml
+[tool.mypy]
+# ... your mypy config
+plugins = ["fastapi_injectable.mypy"]
+```
+
+```python
+@injectable
+def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
+    return Country(capital)
+
+country = get_country() # Now it's happy!
+```
+
 ### Event Loop Management
 
 `fastapi-injectable` includes a powerful loop management system to handle asynchronous code execution in different contexts. This is particularly useful when working with async code in synchronous environments or when you need controlled event loop execution.
@@ -616,9 +645,7 @@ A: Yes! You can freely mix them. For running async code in sync contexts, use th
 
 ### Are type hints fully supported for `injectable()` and `get_injected_obj()`?
 
-A: Currently, type hint support is a work in progress. However, this doesn't affect the core benefits of the package (seamlessly reusing and maintaining consistency in your FastAPI DI system).
-
-We're actively working on improving type hint support, and we'll have good news on this front soon! In the meantime, enjoy the elegant and clean solution that `fastapi-injectable` provides.
+A: Currently, type hint support is available if you are using `mypy` as your static type checker, you can enable the `fastapi-injectable.mypy` plugin in your `mypy.ini` file, or add `fastapi_injectable.mypy` to your `pyproject.toml` file, see [Type Hinting](#type-hinting) for more details.
 
 <hr>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ ignore_missing_imports = true
 implicit_reexport = true
 show_error_codes = true
 show_error_context = true
+plugins = ["fastapi_injectable.mypy"]
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "session"
@@ -114,6 +115,9 @@ tests = ["test", "*/test"]
 parallel = true
 branch = true
 source = ["src"]
+omit = [
+    "src/fastapi_injectable/mypy.py", # The mypy plugin is fragile
+]
 
 [tool.coverage.report]
 show_missing = true

--- a/src/fastapi_injectable/decorator.py
+++ b/src/fastapi_injectable/decorator.py
@@ -1,7 +1,10 @@
 import inspect
 from collections.abc import Awaitable, Callable, Coroutine, Generator
 from functools import wraps
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Annotated, Any, ParamSpec, TypeVar, cast, get_origin, overload
+
+import fastapi
+import fastapi.params
 
 from .concurrency import run_coroutine_sync
 from .main import resolve_dependencies
@@ -17,6 +20,29 @@ else:
 
     def set_original_func(wrapper: Any, target: Any) -> None:  # noqa: ANN401
         wrapper.__original_func__ = target
+
+
+def _override_func_dependency_signature(func: Callable[P, T] | Callable[P, Awaitable[T]]) -> None:  # pragma: no cover
+    """Override the function signature to make dependency-injected parameters optional."""
+    signature = inspect.signature(func)
+    new_parameters = []
+    for param in signature.parameters.values():
+        using_annotated_and_default_is_empty = (
+            get_origin(param.annotation) is Annotated
+            and param.annotation.__metadata__
+            and param.default is inspect.Parameter.empty
+        )
+        parameter = param
+        if using_annotated_and_default_is_empty:
+            fastapi_default = None
+            for metadata in param.annotation.__metadata__:
+                if type(metadata) is fastapi.params.Depends:
+                    fastapi_default = metadata
+                    break
+            if fastapi_default:
+                parameter = inspect.Parameter.replace(param, default=object())
+        new_parameters.append(parameter)
+    func.__signature__ = signature.replace(parameters=new_parameters)  # type: ignore[union-attr]
 
 
 @overload
@@ -56,17 +82,20 @@ def injectable(
     def decorator(
         target: Callable[P, T] | Callable[P, Awaitable[T]],
     ) -> Callable[P, T] | Callable[P, Awaitable[T]]:
+        # Override the function signature to make dependency-injected parameters optional for packages like typer, cyclopt, etc.  # noqa: E501
+        _override_func_dependency_signature(target)
+
         is_async = inspect.iscoroutinefunction(target)
 
         @wraps(target)
         async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             dependencies = await resolve_dependencies(func=target, use_cache=use_cache)
-            return await cast(Callable[..., Coroutine[Any, Any, T]], target)(*args, **{**dependencies, **kwargs})
+            return await cast("Callable[..., Coroutine[Any, Any, T]]", target)(*args, **{**dependencies, **kwargs})
 
         @wraps(target)
         def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             dependencies = run_coroutine_sync(resolve_dependencies(func=target, use_cache=use_cache))
-            return cast(Callable[..., T], target)(*args, **{**dependencies, **kwargs})
+            return cast("Callable[..., T]", target)(*args, **{**dependencies, **kwargs})
 
         if is_async:
             set_original_func(async_wrapper, target)

--- a/src/fastapi_injectable/mypy.py
+++ b/src/fastapi_injectable/mypy.py
@@ -1,0 +1,189 @@
+"""Mypy plugin for fastapi-injectable.
+
+This plugin provides type checking support for the @injectable decorator,
+making Annotated[Type, Depends(...)] parameters optional from the caller's perspective.
+
+Based on patterns from:
+- https://github.com/python/mypy/tree/master/mypy/plugins
+- https://github.com/pydantic/pydantic/blob/main/pydantic/mypy.py
+- https://github.com/dropbox/sqlalchemy-stubs/blob/master/sqlmypy.py
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from mypy.nodes import (
+    ARG_NAMED,
+    ARG_NAMED_OPT,
+    ARG_OPT,
+    ARG_POS,
+    ArgKind,
+    Argument,
+    Decorator,
+    Expression,
+    FuncDef,
+    NameExpr,
+)
+from mypy.plugin import FunctionContext, FunctionSigContext, Plugin
+from mypy.types import CallableType, RawExpressionType, Type, UnboundType
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+INJECTABLE_DECORATOR_FULLNAMES = {
+    "fastapi_injectable.decorator.injectable",
+    "src.fastapi_injectable.decorator.injectable",
+}
+
+
+class FastApiInjectablePlugin(Plugin):
+    """Mypy plugin for fastapi-injectable.
+
+    This plugin modifies function signatures to make dependency-injected parameters
+    optional from the caller's perspective while maintaining type safety.
+    """
+
+    def __init__(self, options: Any) -> None:  # noqa: ANN401
+        """Initialize the plugin."""
+        super().__init__(options)
+
+    def get_function_signature_hook(self, fullname: str) -> Callable[[FunctionSigContext], CallableType] | None:
+        """Hook for modifying function signatures.
+
+        This is called for every function that mypy analyzes.
+        We only process functions decorated with @injectable.
+        """
+        sym_table_node = self.lookup_fully_qualified(fullname)
+        if not sym_table_node or not isinstance(sym_table_node.node, Decorator):
+            return None
+
+        if any(
+            name_expr.fullname in INJECTABLE_DECORATOR_FULLNAMES
+            for name_expr in sym_table_node.node.decorators
+            if isinstance(name_expr, NameExpr)
+        ):
+            return self._process_injectable_function_signature
+
+        return None
+
+    def get_function_hook(self, fullname: str) -> Callable[[FunctionContext], Type] | None:
+        """Hook for modifying method/function calls.
+
+        This handles injectable(func) direct calls.
+        """
+        if fullname in INJECTABLE_DECORATOR_FULLNAMES:
+            return self._process_injectable_call
+        return None
+
+    def _process_injectable_call(self, ctx: FunctionContext) -> Type:
+        """Process injectable(func) direct calls.
+
+        This modifies the return type to make dependency parameters optional.
+        """
+        if not ctx.arg_types or not ctx.arg_types[0]:
+            return ctx.default_return_type
+
+        # Get the function being passed to injectable()
+        original_callable_type = ctx.arg_types[0][0]
+        if not isinstance(original_callable_type, CallableType):
+            return ctx.default_return_type
+
+        # Check if we have access to the function definition
+        if not ctx.args or not ctx.args[0] or not isinstance(ctx.args[0][0], NameExpr):
+            return ctx.default_return_type
+
+        func_node = ctx.args[0][0].node
+        if not isinstance(func_node, FuncDef):
+            return ctx.default_return_type
+
+        # Process the function signature using shared logic
+        modified_arg_kinds = self._modify_arg_kinds_for_dependencies(
+            func_node.arguments, original_callable_type.arg_kinds
+        )
+
+        # Return modified callable type if we made changes
+        if modified_arg_kinds != original_callable_type.arg_kinds:
+            return original_callable_type.copy_modified(arg_kinds=modified_arg_kinds)
+
+        return ctx.default_return_type
+
+    def _process_injectable_function_signature(self, ctx: FunctionSigContext) -> CallableType:
+        """Process the signature of an @injectable decorated function.
+
+        This makes Annotated[Type, Depends(...)] parameters optional.
+        """
+        original_signature = ctx.default_signature
+        decorated_func_def_node: FuncDef = ctx.context.callee.node.func  # type: ignore[attr-defined]
+
+        # Process the function signature using shared logic
+        modified_arg_kinds = self._modify_arg_kinds_for_dependencies(
+            decorated_func_def_node.arguments, original_signature.arg_kinds
+        )
+
+        # Return modified signature if we made changes
+        if modified_arg_kinds != original_signature.arg_kinds:
+            return original_signature.copy_modified(arg_kinds=modified_arg_kinds)
+
+        return original_signature
+
+    def _modify_arg_kinds_for_dependencies(
+        self, arguments: list[Argument], original_arg_kinds: list[ArgKind]
+    ) -> list[ArgKind]:
+        """Modify argument kinds to make dependency-injected parameters optional.
+
+        Args:
+            arguments: List of function argument nodes
+            original_arg_kinds: Original argument kinds from the callable type
+
+        Returns:
+            Modified list of argument kinds
+        """
+        modified_arg_kinds = list(original_arg_kinds)
+
+        # Process each argument
+        for i, arg_node in enumerate(arguments):
+            # Safety check for bounds
+            if i >= len(original_arg_kinds):
+                break
+
+            # Check if this argument has a dependency annotation
+            if arg_node.type_annotation and self._is_fastapi_depends_annotation(arg_node.type_annotation):  # type: ignore[arg-type]
+                current_kind = original_arg_kinds[i]
+
+                # Make required arguments optional
+                if current_kind == ARG_POS:  # Required positional
+                    modified_arg_kinds[i] = ARG_OPT  # Make optional positional
+                elif current_kind == ARG_NAMED:  # Required keyword-only
+                    modified_arg_kinds[i] = ARG_NAMED_OPT  # Make optional keyword-only
+
+        return modified_arg_kinds
+
+    def _is_fastapi_depends_annotation(self, type_expr: Expression) -> bool:
+        """Check if a type annotation is Annotated[Type, Depends(...)].
+
+        This method handles the complex AST traversal to identify dependency annotations.
+        """
+        if not isinstance(type_expr, UnboundType):  # type: ignore[unreachable]
+            return False
+
+        # type_expr -> Annotated[Type, Depends(...)], type_expr.args -> (Type, None)
+        if type_expr.name != "Annotated" or len(type_expr.args) < 2:  # type: ignore[unreachable]  # noqa: PLR2004
+            return False
+
+        # Suggestion: use Depends[...] instead of Depends(...) is where the magic happens
+        # https://github.com/python/mypy/blob/a8ec8939ce5a8ba332ec428bec8c4b7ef8c42344/mypy/fastparse.py#L1958-L1969
+        # Since there is no way to get the annotation metadata from mypy as of now, ref: https://github.com/python/mypy/pull/9625
+        # So the metadata will be a None in type_expr.args, hopefully, the note will indicate that the annotation is a Depends annotation  # noqa: E501
+        # so we can rely on the note to determine if the annotation is a Depends annotation for now.
+        return any(
+            arg.note == "Suggestion: use Depends[...] instead of Depends(...)"
+            for arg in type_expr.args
+            if isinstance(arg, RawExpressionType)
+        )
+
+
+def plugin(version: str) -> type[Plugin]:  # noqa: ARG001
+    """Mypy plugin entry point."""
+    return FastApiInjectablePlugin


### PR DESCRIPTION
# Add MyPy Plugin for Enhanced Type Checking Support

## 🎯 Overview

This PR introduces a comprehensive mypy plugin that resolves type checking issues with the `@injectable` decorator, making `Annotated[Type, Depends(...)]` parameters optional from the caller's perspective while maintaining full type safety.

## ✨ Key Features

### MyPy Plugin (`src/fastapi_injectable/mypy.py`)
- **Smart Signature Analysis**: Automatically detects `@injectable` decorated functions
- **Dependency Recognition**: Identifies `Annotated[Type, Depends(...)]` parameters using AST traversal
- **Argument Kind Modification**: Converts required arguments to optional for dependency-injected parameters
- **Dual Hook System**: Supports both decorator and direct function call patterns

### Runtime Enhancement (`decorator.py`)
- Added `_override_func_dependency_signature()` for runtime signature modification
- Enhanced compatibility with CLI frameworks like typer, cyclopt, etc.
- Improved type casting with string literals for better mypy compliance

## 📖 Documentation & Configuration

### New Type Hinting Section in README
- Clear explanation of the mypy plugin usage
- Before/after code examples showing the problem and solution
- Configuration instructions for both `mypy.ini` and `pyproject.toml`

### Updated FAQ
- Replaced "work in progress" message with concrete mypy plugin information
- Added direct reference to the Type Hinting section

### Project Configuration
- Added mypy plugin to `pyproject.toml` configuration
- Excluded mypy plugin from coverage (due to its fragile nature)

## 🔧 Technical Implementation

The plugin uses mypy's hook system to:

1. **Function Signature Hook**: Processes `@injectable` decorated functions
2. **Function Call Hook**: Handles `injectable(func)` direct calls
3. **AST Analysis**: Detects FastAPI `Depends()` annotations via note matching
4. **Argument Transformation**: Converts `ARG_POS` → `ARG_OPT` and `ARG_NAMED` → `ARG_NAMED_OPT`

## 🎯 Benefits

- ✅ **No More Type Errors**: Eliminates mypy complaints about missing arguments
- ✅ **Zero Runtime Impact**: Plugin only affects static analysis
- ✅ **Maintains Type Safety**: Full type checking for actual dependencies
- ✅ **Easy Integration**: Simple plugin configuration
- ✅ **Framework Compatibility**: Works with various CLI and web frameworks

## 📝 Usage Example

```python
# Before: mypy complains about missing arguments
@injectable
def get_country(capital: Annotated[Capital, Depends(get_capital)]) -> Country:
    return Country(capital)

country = get_country()  # ❌ mypy error: Missing positional arguments

# After: With plugin enabled
country = get_country()  # ✅ mypy happy!
```

## 🔄 Breaking Changes

None - this is a purely additive feature that enhances the existing functionality without changing any APIs.