### PR TITLE
feat: allow manual override of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ print(result) # Output: 'data'
 
 ## Key Features
 
-1. **Flexible Injection**: Use decorators, function wrappers, or utility functions.
-2. **Full Async Support**: Works with both sync and async code.
-3. **Resource Management**: Built-in cleanup for dependencies.
-4. **Dependency Caching**: Optional caching for better performance.
-5. **Graceful Shutdown**: Automatic cleanup on program exit.
-6. **Event Loop Management**: Control the event loop to ensure the objects created by `fastapi-injectable` are executed in the right loop.
+1. **Basic Injection**: Use decorators, function wrappers, or utility functions.
+2. **Manual Overrides**: Explicit arguments you pass always take priority over injected dependencies (great for tests and mocks).
+3. **Full Async Support**: Works with both sync and async code.
+4. **Resource Management**: Built-in cleanup for dependencies.
+5. **Dependency Caching**: Optional caching for better performance.
+6. **Graceful Shutdown**: Automatic cleanup on program exit.
+7. **Event Loop Management**: Control the event loop to ensure the objects created by `fastapi-injectable` are executed in the right loop.
 
 ## Overview
 
@@ -146,6 +147,42 @@ def process_data(db: Annotated[Database, Depends(get_database)]):
 # Get injected instance without decorator
 result = get_injected_obj(process_data)
 print(result) # Output: 'data'
+```
+
+### Manual Overrides
+
+Sometimes you want to use FastAPI’s dependency injection system, but still explicitly pass certain arguments yourself.
+
+For example, in tests you may want to supply a mock instead of the default dependency, or in CLI tools you may want to provide a value directly.
+
+`fastapi-injectable` makes this possible by allowing manual overrides: any arguments you pass will take priority over injected dependencies.
+
+```python
+from typing import Annotated
+from fastapi import Depends
+from fastapi_injectable import get_injected_obj, injectable
+
+class Database:
+    def query(self) -> str:
+        return "real data"
+
+def get_db() -> Database:
+    return Database()
+
+@injectable
+def process_data(db: Annotated[Database, Depends(get_db)]) -> str:
+    return db.query()
+
+# Normal usage – resolved through DI
+print(process_data())
+# Output: "real data"
+
+# Override dependency manually (great for tests)
+mock_db = Database()
+mock_db.query = lambda: "mock data"
+
+print(process_data(db=mock_db)) # Explicitly pass the mock dependency
+# Output: "mock data"
 ```
 
 ### Generator Dependencies with Cleanup

--- a/src/fastapi_injectable/decorator.py
+++ b/src/fastapi_injectable/decorator.py
@@ -125,18 +125,20 @@ def injectable(
 
         @wraps(target)
         async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-            dependencies = await resolve_dependencies(func=target, use_cache=use_cache)
+            dependencies = await resolve_dependencies(func=target, use_cache=use_cache, provided_kwargs=kwargs)
             return await cast("Callable[..., Coroutine[Any, Any, T]]", target)(*args, **{**dependencies, **kwargs})
 
         @wraps(target)
         async def async_gen_wrapper(*args: P.args, **kwargs: P.kwargs) -> AsyncGenerator[T, Any]:
-            dependencies = await resolve_dependencies(func=target, use_cache=use_cache)
+            dependencies = await resolve_dependencies(func=target, use_cache=use_cache, provided_kwargs=kwargs)
             async for x in cast("Callable[..., AsyncGenerator[T, Any]]", target)(*args, **{**dependencies, **kwargs}):
                 yield x
 
         @wraps(target)
         def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-            dependencies = run_coroutine_sync(resolve_dependencies(func=target, use_cache=use_cache))
+            dependencies = run_coroutine_sync(
+                resolve_dependencies(func=target, use_cache=use_cache, provided_kwargs=kwargs)
+            )
             return cast("Callable[..., T]", target)(*args, **{**dependencies, **kwargs})
 
         if is_async_generator:


### PR DESCRIPTION

## Purpose

This PR introduces a new feature that allows for the manual override of dependencies in `fastapi-injectable`. It also fixes issue #133, where explicitly provided dependencies were still being resolved by the dependency injection system.

## Key Changes

-   **Manual Overrides**: You can now explicitly pass arguments to an `@injectable` function, and they will take priority over the dependencies that would normally be injected. This is great for testing and for providing values directly in CLI applications.

    ```python
    from typing import Annotated
    from fastapi import Depends
    from fastapi_injectable import injectable

    class Database:
        def query(self) -> str:
            return "real data"

    def get_db() -> Database:
        return Database()

    @injectable
    def process_data(db: Annotated[Database, Depends(get_db)]) -> str:
        return db.query()

    # Normal usage – resolved through DI
    print(process_data())
    # Output: "real data"

    # Override dependency manually (great for tests)
    class MockDB:
        def query(self) -> str:
            return "mock data"

    print(process_data(db=MockDB())) # Explicitly pass the mock dependency
    # Output: "mock data"
    ```

-   **Bug Fix**: Previously, `fastapi-injectable` would still attempt to resolve a dependency even if it was passed as an argument, which could lead to unexpected errors. This has been fixed.

-   **Updated Documentation**: The `README.md` has been updated to include a section on manual overrides.

-   **New Tests**: Added tests to ensure that manual overrides work as expected for sync, async, and async generator functions.

## How it Works

The `resolve_dependencies` function now accepts `provided_kwargs`. Before resolving dependencies, it checks if any of the required dependencies are already present in `provided_kwargs`. If so, it skips the resolution for those dependencies.

This PR improves the flexibility and testability of applications using `fastapi-injectable`.