### PR TITLE
feat: add async_get_injected_obj for running event loops

### DIFF
--- a/src/fastapi_injectable/__init__.py
+++ b/src/fastapi_injectable/__init__.py
@@ -2,6 +2,7 @@ from .concurrency import loop_manager, run_coroutine_sync
 from .decorator import injectable
 from .main import register_app, resolve_dependencies
 from .util import (
+    async_get_injected_obj,
     cleanup_all_exit_stacks,
     cleanup_exit_stack_of_func,
     clear_dependency_cache,
@@ -10,6 +11,7 @@ from .util import (
 )
 
 __all__ = [
+    "async_get_injected_obj",
     "cleanup_all_exit_stacks",
     "cleanup_exit_stack_of_func",
     "clear_dependency_cache",


### PR DESCRIPTION
# Purpose
Fix `RuntimeError: This event loop is already running ` when using dependency injection in running event loops by introducing `async_get_injected_obj()` for async contexts like Kafka consumers and streaming frameworks (any async worker scenarios).

# Changes

### TL;DR
- Added `async_get_injected_obj()` for use in running event loops (fixes #173)
- Works with async functions and async generators
- Complements existing `get_injected_obj()` for sync contexts
- Comprehensive docs with comparison table and real-world examples
- 9 new integration tests covering all scenarios

---

Introduce `async_get_injected_obj()` to resolve RuntimeError when calling dependency injection from within already-running event loops (e.g., Kafka consumers, async callbacks).

The existing `get_injected_obj()` uses `loop.run_until_complete()` internally, which fails with "This event loop is already running" when called from async contexts. The new async version directly awaits coroutines, making it safe for these scenarios.

**Key changes:**

- Add `_create_async_depends_function()` helper that creates async pass-through dependencies to trigger the async_wrapper path in the `injectable` decorator
- Implement `async_get_injected_obj()` function that must be awaited and works with running event loops
- Add comprehensive documentation in README explaining when to use each function, with examples for Kafka/kstreams consumers
- Add comparison table and FAQ entry for clarity
- Include 9 integration tests covering async functions, async generators, dependencies, caching, and nested dependencies
- Export new function in `__init__.py`

**Breaking changes:** None