### PR TITLE
feat: add support for free-threaded Python builds (`3.14t`, `3.13t`)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,17 +24,23 @@ jobs:
           - { python: "3.11", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.10", os: "ubuntu-latest", session: "mypy" }
           - { python: "3.14", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.14t", os: "ubuntu-latest", session: "tests" }
           - { python: "3.13", os: "ubuntu-latest", session: "tests" }
+          - { python: "3.13t", os: "ubuntu-latest", session: "tests" }
           - { python: "3.12", os: "ubuntu-latest", session: "tests" }
           - { python: "3.11", os: "ubuntu-latest", session: "tests" }
           - { python: "3.10", os: "ubuntu-latest", session: "tests" }
           - { python: "3.14", os: "windows-latest", session: "tests" }
+          - { python: "3.14t", os: "windows-latest", session: "tests" }
           - { python: "3.13", os: "windows-latest", session: "tests" }
+          - { python: "3.13t", os: "windows-latest", session: "tests" }
           - { python: "3.12", os: "windows-latest", session: "tests" }
           - { python: "3.11", os: "windows-latest", session: "tests" }
           - { python: "3.10", os: "windows-latest", session: "tests" }
           - { python: "3.14", os: "macos-latest", session: "tests" }
+          - { python: "3.14t", os: "macos-latest", session: "tests" }
           - { python: "3.13", os: "macos-latest", session: "tests" }
+          - { python: "3.13t", os: "macos-latest", session: "tests" }
           - { python: "3.12", os: "macos-latest", session: "tests" }
           - { python: "3.11", os: "macos-latest", session: "tests" }
           - { python: "3.10", os: "macos-latest", session: "tests" }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,10 @@ Request features on the [Issue Tracker].
 
 ## How to set up your development environment
 
-You need to have Python 3.10, 3.11, 3.12, 3.13, 3.14 installed. With uv, you can easily install and manage multiple Python versions:
+You need to have Python 3.10, 3.11, 3.12, 3.13, 3.13t, 3.14, 3.14t installed. With uv, you can easily install and manage multiple Python versions:
 
 ```console
-$ uv python install 3.10 3.11 3.12 3.13 3.14
+$ uv python install 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t
 ```
 
 **Note:** uv will be installed automatically when you run the commands above. Alternatively, you can install uv manually by following the instructions on the [official website](https://astral.sh/uv/install.sh). This project requires uv version 0.9.2 or higher. You can verify your version with `uv --version`.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ print(result) # Output: 'data'
 
 ### Requirements
 
-- Python `3.10` or higher
+- Python `3.10` or higher (including `3.13t`, `3.14t` free-threaded builds)
 - FastAPI `0.112.4` or higher
 
 <!-- homepage-end -->

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,8 +8,9 @@ from textwrap import dedent
 import nox
 
 package = "fastapi_injectable"
-python_versions = ["3.10", "3.11", "3.12", "3.13", "3.14"]
-latest_python_version = python_versions[-1]
+python_versions = ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
+python_versions_without_free_threaded = [version for version in python_versions if not version.endswith("t")]
+latest_python_version = python_versions_without_free_threaded[-1]
 nox.needs_version = ">= 2025.05.01"
 nox.options.sessions = (
     "pre-commit",
@@ -108,7 +109,7 @@ def precommit(session: nox.Session) -> None:
         activate_virtualenv_in_precommit_hooks(session)
 
 
-@nox.session(python=python_versions)
+@nox.session(python=python_versions_without_free_threaded)
 def mypy(session: nox.Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or ["src", "test", "docs/conf.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 3 - Stable",
     "Framework :: FastAPI",
     "License :: OSI Approved :: MIT License",
 ]


### PR DESCRIPTION
# Purpose
Add comprehensive support for Python 3.13t and 3.14t free-threaded builds, enabling the project to work with Python's experimental free-threaded mode that removes the Global Interpreter Lock (GIL).

# Changes

### TL;DR
Added CI testing for Python 3.13t/3.14t free-threaded builds across all platforms, updated documentation and build configuration, and intelligently excluded free-threaded versions from mypy checks while keeping them in test runs.

---

Add comprehensive support for Python 3.13t and 3.14t free-threaded builds across the project infrastructure. This includes CI pipeline updates, documentation updates, and build configuration changes.

- Add test matrix entries for 3.13t and 3.14t across all OS platforms (Ubuntu, Windows, macOS) in GitHub Actions workflow
- Update development environment setup instructions in CONTRIBUTING.md to include free-threaded Python versions
- Modify noxfile.py to create separate `python_versions_without_free_threaded` list for sessions that don't support free-threaded builds (e.g., `mypy` session)
- Add PyPI classifier "Programming Language :: Python :: Free Threading :: 3 - Stable" to pyproject.toml
- Update README.md requirements section to explicitly mention support for free-threaded builds

The `mypy` type-checking session explicitly excludes free-threaded versions since type checkers may not yet fully support these builds, while all other test sessions run on both standard and free-threaded Python versions.