### PR TITLE
chore: bump version to 1.4.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi-injectable"
-version = "1.4.6"
+version = "1.4.7"
 description = "Use FastAPI's Depends() anywhere — in CLI tools, Celery tasks, background workers, and more. No refactoring needed."
 authors = [{ name = "Jasper Sui", email = "suiyang03@gmail.com" }]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bump version from 1.4.6 to 1.4.7 for the next patch release

## Changes
- Fix: filter non-Depends params from `get_dependant` to support bound tasks (#215)
- Test: add integration tests for Celery, Dramatiq, and Temporal (#216)