### PR TITLE
fix: drop dependency cache when its event loop is closed (#186)

### DIFF
--- a/src/fastapi_injectable/cache.py
+++ b/src/fastapi_injectable/cache.py
@@ -1,14 +1,49 @@
 import asyncio
 from typing import Any
 
+from .concurrency import loop_manager
+
 
 class DependencyCache:
+    """Dependency resolution cache, invalidated when its event loop dies.
+
+    The resolved dependency values are shared in a single dict, but that dict
+    is dropped as soon as the event loop that populated it has been closed and
+    a different loop becomes active.
+
+    On a cache hit FastAPI's ``solve_dependencies`` returns the cached value
+    without re-entering the provider. A resource resolved on a now-closed loop
+    (and any loop-bound asyncio primitive it holds, e.g. an ``asyncio.Lock``)
+    must never be reused on a live loop -- doing so blocks forever with no
+    error. That is the silent deadlock in
+    https://github.com/JasperSui/fastapi-injectable/issues/186.
+
+    Values resolved on a loop that is still open are kept even when a different
+    loop becomes active, so in-process cache sharing across calls (e.g. repeated
+    ``get_injected_obj`` calls, whose synchronous helper may run on a different
+    event loop object each time) keeps returning the same instances.
+    """
+
     def __init__(self) -> None:
         self._cache: dict[Any, Any] = {}
         self._lock = asyncio.Lock()
+        # The event loop that populated the current cache contents. A strong
+        # reference to a single loop is kept (and replaced whenever the active
+        # loop changes), which is enough to ask whether it has been closed.
+        self._owner_loop: asyncio.AbstractEventLoop | None = None
+
+    def _drop_cache_if_owner_loop_closed(self) -> None:
+        """Drop cached values that belong to a closed event loop (see #186)."""
+        current = loop_manager.get_loop()
+        if self._owner_loop is current:
+            return
+        if self._owner_loop is not None and self._owner_loop.is_closed():
+            self._cache.clear()
+        self._owner_loop = current
 
     def get(self) -> dict[Any, Any]:
-        """Get the current cache."""
+        """Get the current cache, dropping values owned by a closed loop."""
+        self._drop_cache_if_owner_loop_closed()
         return self._cache
 
     async def clear(self) -> None:

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any
 
 import pytest
 
@@ -40,3 +41,73 @@ async def test_clear_lock(cache: DependencyCache) -> None:
         assert not clear_task.done()
     await clear_task
     assert cache.get() == {}
+
+
+def test_cache_is_shared_within_the_same_event_loop() -> None:
+    cache = DependencyCache()
+    sentinel = object()
+
+    async def scenario() -> None:
+        cache.get()["key"] = sentinel
+        assert cache.get()["key"] is sentinel
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(scenario())
+    finally:
+        loop.close()
+
+
+def test_cache_is_retained_across_still_open_event_loops() -> None:
+    """A value resolved on a loop that is still open is reused on another loop.
+
+    This preserves in-process cache sharing for repeated ``get_injected_obj``
+    calls, whose synchronous helper may run on a different event loop object
+    each time while every loop stays open.
+    """
+    cache = DependencyCache()
+    sentinel = object()
+
+    async def store() -> None:
+        cache.get()["key"] = sentinel
+
+    async def fetch() -> object | None:
+        return cache.get().get("key")
+
+    loop_a = asyncio.new_event_loop()
+    loop_b = asyncio.new_event_loop()
+    try:
+        loop_a.run_until_complete(store())
+        # loop_a is still OPEN, so its cached value must survive on loop_b.
+        assert loop_b.run_until_complete(fetch()) is sentinel
+    finally:
+        loop_a.close()
+        loop_b.close()
+
+
+def test_cache_is_dropped_when_owner_loop_closed() -> None:
+    """Regression for https://github.com/JasperSui/fastapi-injectable/issues/186.
+
+    A value resolved on a now-closed event loop must never be served to a
+    later, different loop -- it may hold a loop-bound asyncio primitive that
+    would deadlock silently if reused.
+    """
+    cache = DependencyCache()
+
+    async def store() -> None:
+        cache.get()["key"] = object()
+
+    loop_a = asyncio.new_event_loop()
+    loop_a.run_until_complete(store())
+    loop_a.close()  # owner loop is now dead
+
+    async def fetch() -> dict[Any, Any]:
+        return cache.get()
+
+    loop_b = asyncio.new_event_loop()
+    try:
+        fresh = loop_b.run_until_complete(fetch())
+    finally:
+        loop_b.close()
+
+    assert fresh == {}


### PR DESCRIPTION
## Summary

Fixes #186 — `await async_get_injected_obj(Handler)` (default `use_cache=True`) could **hang silently** (no error, no timeout) across multiple async tests, e.g. resolving a handler in an autouse fixture and awaiting it in each test.

## Root cause

The module-global `dependency_cache` was a **single dict that was never invalidated**. On a cache HIT, FastAPI's `solve_dependencies` does not re-enter the provider, so a resource instance built on an earlier (now-closed) event loop was reused on a later loop. If that resource holds a **loop-bound asyncio primitive in a silently-parking state** — e.g. an uncontended `asyncio.Lock` whose `_loop` stays `None`, which re-binds to the new loop *without* raising `bound to a different event loop` — awaiting it on the new loop blocks forever.

Confirmed with a deterministic toggle proof:

| Condition | Result |
|---|---|
| `use_cache=True` + sub-dependency holding a loop-bound primitive | **hangs** (Py 3.10 & 3.13) |
| `use_cache=False` | passes (bypasses the global cache — the reporter's clue) |
| autouse `await clear_dependency_cache()` between tests | passes → **the global cache is the poison** |
| autouse `await cleanup_all_exit_stacks()` | still hangs → exit-stack leak is *not* the trigger (matches the reporter) |

The hang's thread dump sits idle in `selectors.select()` — a deadlock signature, not an exception. A naive minimal repro doesn't hang because its sub-dependencies resolve to plain, non-loop-bound values; a real resource (DB pool / redis / grpc / aiosqlite client mutex) is required to trigger it, which is why the trivial repro attempt couldn't reproduce it.

## Fix

Track the event loop that populated the cache and **drop the cached values when that loop has been closed and a different loop becomes active** — the precise dangerous condition. Existing same-process cache sharing is otherwise untouched:

- **Same loop** → cache is shared (unchanged).
- **Different but still-open loop** → cache is kept, so repeated `get_injected_obj` calls — whose synchronous helper may run on a different event loop object each time — keep returning the same cached instances (preserves the documented `country_1.capital is country_2.capital` contract).
- **Owner loop closed + a new loop active** → cache is dropped, so the stale loop-bound resource is never reused and is resolved fresh on the live loop.

**Public API is unchanged.**

> Earlier revision note: an initial attempt fully partitioned the cache per event loop, which broke the sync `get_injected_obj` same-instance contract when its helper runs on a different loop object across calls (caught by CI's `coverage run -m pytest` under nox). This conservative close-detection approach fixes #186 without that regression.

### Scope note

This fixes the realistic case — clients that release their lock per request (real DB/redis/grpc, the reporter's situation). A pathological resource that holds a lock acquired *forever* and is reused **on the same loop** is a self-deadlock inherent to caching such a resource and still requires `use_cache=False`; no cache scoping can fix that without breaking the same-loop caching contract.

## Tests

Adds regression tests in `test/test_cache.py`: same-loop sharing, retention across still-open loops, and dropping after the owner loop closes.

## Verification (all green locally, CI-equivalent via nox)

- `ruff check .` → passed
- `nox -s mypy` → Success, 26 + 1 source files
- `nox -s tests-3.10` (`coverage run --parallel-mode -m pytest`) → 151 passed
- `coverage report --fail-under=100` → 100% (exit 0)