### PR TITLE
feat: add injectable_scope() for isolated per-task dependency lifecycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,60 @@ These test cases mirror common development patterns you'll encounter. They show 
 
 The test files are written to be self-documenting, so browsing through them will give you practical examples for most scenarios you'll face in your codebase.
 
+### 3. Isolated dependency scopes for parallel work
+
+By default, the exit stack that holds a dependency's cleanup is keyed by the **function**, so every concurrent call of the same injectable shares one stack. When you process events in parallel (for example, an async consumer fanning work out through `asyncio.TaskGroup`), that shared stack makes per-event cleanup unsafe — cleaning up one event can tear down another's in-flight resources.
+
+`injectable_scope()` gives each unit of work its **own** exit stack *and* cache — the same request-scoped model FastAPI uses internally. Enter the scope inside each task; `contextvars` keeps the tasks isolated:
+
+```python
+import asyncio
+from collections.abc import AsyncGenerator
+
+from fastapi_injectable import async_get_injected_obj, injectable_scope
+
+
+async def get_connection() -> AsyncGenerator[Connection, None]:
+    conn = await open_connection()
+    try:
+        yield conn
+    finally:
+        await conn.close()
+
+
+async def process_event(event) -> None:
+    async with injectable_scope():
+        conn = await async_get_injected_obj(get_connection)
+        await handle(event, conn)
+    # only this event's connection is closed here — siblings are untouched
+
+
+async def consume(events) -> None:
+    async with asyncio.TaskGroup() as tg:  # Python 3.11+; use asyncio.gather() on 3.10
+        for event in events:
+            tg.create_task(process_event(event))
+```
+
+#### Sharing one scope explicitly
+
+`InjectableScope` is also usable directly when you want to manage a scope's lifecycle yourself and inject into it from several places. Pass it with `scope=`; this routes resolution into that scope without taking ownership of it (you close it):
+
+```python
+from fastapi_injectable import InjectableScope, async_get_injected_obj
+
+scope = InjectableScope()
+async with scope:
+    a = await async_get_injected_obj(get_a, scope=scope)
+    scope.exit_stack.push_async_callback(my_cleanup)  # rides the same lifecycle
+# a and my_cleanup are torn down together when the block exits
+```
+
+#### Notes & limitations
+
+- Inside a scope, `cleanup_exit_stack_of_func()` / `cleanup_all_exit_stacks()` are no-ops for the scope's resources — the `async with` owns cleanup.
+- With no active scope, behavior is unchanged (the global, function-keyed manager and the `cleanup_*` helpers work exactly as before).
+- `injectable_scope` is **async-first**. Under the `background_thread` loop strategy, `contextvars` are not propagated across threads, so a scope is not visible inside the background loop. Use the async API for scoped resolution.
+
 <!-- advanced-scenarios-end -->
 
 ## Real-world Examples
@@ -675,7 +729,7 @@ This example demonstrates several key patterns for using dependency injection in
 
 2. **Proper Resource Management**:
    - Dependencies with cleanup needs (like database connections) are properly handled
-   - Cleanup code in generators runs when `cleanup_exit_stack_of_func()` is called
+   - Cleanup code in generators runs when `cleanup_exit_stack_of_func()` is called, or automatically at the end of an `injectable_scope()` block
    - Cache is cleared between messages to prevent memory leaks
 
 3. **Graceful Shutdown**:

--- a/docs/real-world-examples.md
+++ b/docs/real-world-examples.md
@@ -12,7 +12,7 @@ This example demonstrates several key patterns for using dependency injection in
 
 2. **Proper Resource Management**:
    - Dependencies with cleanup needs (like database connections) are properly handled
-   - Cleanup code in generators runs when `cleanup_exit_stack_of_func()` is called
+   - Cleanup code in generators runs when `cleanup_exit_stack_of_func()` is called, or automatically at the end of an `injectable_scope()` block
    - Cache is cleared between messages to prevent memory leaks
 
 3. **Graceful Shutdown**:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,9 +157,15 @@ tests = ["test", "*/test"]
 [tool.coverage.run]
 parallel = true
 branch = true
+# Most tests import the package via the ``src.fastapi_injectable`` path, but a
+# few (e.g. test_scope) import it as the installed ``fastapi_injectable``
+# package. Measure both so coverage is captured regardless of import style;
+# [tool.coverage.paths] then folds the two into a single source tree.
 source = ["src"]
+source_pkgs = ["fastapi_injectable"]
 omit = [
     "src/fastapi_injectable/mypy.py", # The mypy plugin is fragile
+    "*/fastapi_injectable/mypy.py", # ...also when measured via the installed package path
 ]
 
 [tool.coverage.report]

--- a/src/fastapi_injectable/__init__.py
+++ b/src/fastapi_injectable/__init__.py
@@ -1,6 +1,7 @@
 from .concurrency import loop_manager, run_coroutine_sync
 from .decorator import injectable
 from .main import register_app, resolve_dependencies
+from .scope import InjectableScope, injectable_scope
 from .util import (
     async_get_injected_obj,
     cleanup_all_exit_stacks,
@@ -11,6 +12,7 @@ from .util import (
 )
 
 __all__ = [
+    "InjectableScope",
     "async_get_injected_obj",
     "cleanup_all_exit_stacks",
     "cleanup_exit_stack_of_func",
@@ -18,6 +20,7 @@ __all__ = [
     "configure_logging",
     "get_injected_obj",
     "injectable",
+    "injectable_scope",
     "loop_manager",
     "register_app",
     "resolve_dependencies",

--- a/src/fastapi_injectable/main.py
+++ b/src/fastapi_injectable/main.py
@@ -10,6 +10,7 @@ from fastapi.dependencies.utils import get_dependant, solve_dependencies
 
 from .async_exit_stack import async_exit_stack_manager
 from .cache import dependency_cache
+from .scope import _current_scope
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -102,7 +103,12 @@ async def resolve_dependencies(
     root_dep.dependencies = effective_dependencies
 
     root_dep.call = cast("Callable[..., Any]", func)
-    async_exit_stack = await async_exit_stack_manager.get_stack(root_dep.call)
+
+    scope = _current_scope.get()
+    if scope is not None:
+        async_exit_stack = scope.exit_stack
+    else:
+        async_exit_stack = await async_exit_stack_manager.get_stack(root_dep.call)
 
     # Use isolated stacks for FastAPI's internal logic to prevent conflicts.
     # We must ensure they are closed when our main stack is closed.
@@ -125,7 +131,10 @@ async def resolve_dependencies(
     if app is not None:
         fake_request_scope["app"] = app
     fake_request = Request(fake_request_scope)
-    cache = dependency_cache.get() if use_cache else None
+    if scope is not None:
+        cache = scope.get_cache() if use_cache else None
+    else:
+        cache = dependency_cache.get() if use_cache else None
     solved_dependency = await solve_dependencies(
         request=fake_request,
         dependant=root_dep,

--- a/src/fastapi_injectable/scope.py
+++ b/src/fastapi_injectable/scope.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import contextvars
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from types import TracebackType
+
+    from typing_extensions import Self
+
+_current_scope: contextvars.ContextVar[InjectableScope | None] = contextvars.ContextVar(
+    "fastapi_injectable_current_scope", default=None
+)
+
+
+class InjectableScope:
+    """An isolated dependency lifecycle: a private exit stack + dependency cache.
+
+    Entering the scope (``async with``) registers it as the active scope for the
+    current asyncio context. Any dependency resolution that happens while it is
+    active routes its generator cleanup into this scope's exit stack and its
+    cached values into this scope's cache. Leaving the scope closes the exit
+    stack (running all cleanup) and drops the cache.
+    """
+
+    def __init__(self, *, use_cache: bool = True) -> None:
+        self._exit_stack = AsyncExitStack()
+        self._cache: dict[Any, Any] | None = {} if use_cache else None
+        self._token: contextvars.Token[InjectableScope | None] | None = None
+
+    @property
+    def exit_stack(self) -> AsyncExitStack:
+        """The scope's exit stack.
+
+        Push your own cleanup callbacks here to ride the same lifecycle as the
+        scope's dependencies.
+        """
+        return self._exit_stack
+
+    def get_cache(self) -> dict[Any, Any] | None:
+        """The scope's dependency cache (``None`` when caching is disabled)."""
+        return self._cache
+
+    async def __aenter__(self) -> Self:
+        await self._exit_stack.__aenter__()
+        self._token = _current_scope.set(self)
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None:
+        # Reset the active scope BEFORE closing the stack: this guarantees that
+        # any dependency resolution triggered during cleanup never routes back
+        # into the stack we are currently tearing down.
+        if self._token is not None:
+            _current_scope.reset(self._token)
+            self._token = None
+        return await self._exit_stack.__aexit__(exc_type, exc_val, exc_tb)
+
+
+@asynccontextmanager
+async def injectable_scope(*, use_cache: bool = True) -> AsyncIterator[InjectableScope]:
+    """Open an isolated dependency scope for the duration of the ``async with`` block.
+
+    Inside the block every dependency resolved (via ``async_get_injected_obj`` or
+    by calling an ``@injectable`` function) uses this scope's private exit stack
+    and cache. Leaving the block cleans up only this scope's resources, isolated
+    from any other concurrent scope.
+
+    Example::
+
+        async def process_event(event):
+            async with injectable_scope():
+                dep = await async_get_injected_obj(get_dep)
+                await handle(event, dep)
+            # only this event's resources are cleaned up here
+    """
+    async with InjectableScope(use_cache=use_cache) as scope:
+        yield scope

--- a/src/fastapi_injectable/util.py
+++ b/src/fastapi_injectable/util.py
@@ -11,6 +11,7 @@ from .async_exit_stack import async_exit_stack_manager
 from .cache import dependency_cache
 from .concurrency import run_coroutine_sync
 from .decorator import injectable
+from .scope import InjectableScope, _current_scope
 
 T = TypeVar("T")
 T2 = TypeVar("T2")
@@ -169,6 +170,7 @@ def get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
+    scope: InjectableScope | None = None,
 ) -> T: ...
 
 
@@ -179,6 +181,7 @@ def get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
+    scope: InjectableScope | None = None,
 ) -> T: ...
 
 
@@ -189,6 +192,7 @@ def get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
+    scope: InjectableScope | None = None,
 ) -> T: ...
 
 
@@ -199,6 +203,7 @@ def get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
+    scope: InjectableScope | None = None,
 ) -> T: ...
 
 
@@ -213,6 +218,7 @@ def get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
+    scope: InjectableScope | None = None,
 ) -> T:
     """Get an injected object from a dependency function with FastAPI's dependency injection.
 
@@ -228,6 +234,11 @@ def get_injected_obj(
         args: Positional arguments to pass to the dependency function.
         kwargs: Keyword arguments to pass to the dependency function.
         use_cache: Whether to cache resolved dependencies. Defaults to True.
+        scope: An explicit ``InjectableScope`` to route this resolution into,
+            without entering it as the active scope. When provided, the
+            ContextVar is temporarily set for the duration of the call and
+            reset in a ``finally`` block, so it never leaks to the caller.
+            Defaults to ``None`` (use the active scope or global manager).
 
     Returns:
         The first value yielded/returned by the dependency function after injection.
@@ -259,6 +270,11 @@ def get_injected_obj(
         - For generator functions, only the first yielded value is returned
         - Cleanup code in generators will be executed when calling cleanup functions
         - Uses FastAPI's dependency injection system under the hood
+        - The ``scope`` parameter is async-first. Under the ``background_thread``
+          loop strategy the ContextVar is not propagated across threads, so an
+          explicit scope is not visible inside the background loop. Prefer the
+          async API (``async_get_injected_obj`` / ``injectable_scope``) for
+          scoped resolution.
     """
     if args is None:
         args = []
@@ -272,11 +288,16 @@ def get_injected_obj(
 
     wrapped_func = _create_depends_function(func)
     injectable_func = injectable(wrapped_func, use_cache=use_cache)
-    result = injectable_func()  # type: ignore[no-untyped-call]
 
-    if inspect.isawaitable(result):
-        return cast("T", run_coroutine_sync(result))  # type: ignore[arg-type] # pragma: no cover
-    return cast("T", result)
+    token = _current_scope.set(scope) if scope is not None else None
+    try:
+        result = injectable_func()  # type: ignore[no-untyped-call]
+        if inspect.isawaitable(result):
+            return cast("T", run_coroutine_sync(result))  # type: ignore[arg-type] # pragma: no cover
+        return cast("T", result)
+    finally:
+        if token is not None:
+            _current_scope.reset(token)
 
 
 @overload
@@ -286,6 +307,7 @@ async def async_get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
+    scope: InjectableScope | None = None,
 ) -> T: ...
 
 
@@ -296,6 +318,7 @@ async def async_get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
+    scope: InjectableScope | None = None,
 ) -> T: ...
 
 
@@ -305,6 +328,7 @@ async def async_get_injected_obj(
     kwargs: dict[str, Any] | None = None,
     *,
     use_cache: bool = True,
+    scope: InjectableScope | None = None,
 ) -> T:
     """Async version of get_injected_obj() for use in running event loops.
 
@@ -322,6 +346,13 @@ async def async_get_injected_obj(
         args: Positional arguments to pass to the dependency function.
         kwargs: Keyword arguments to pass to the dependency function.
         use_cache: Whether to cache resolved dependencies. Defaults to True.
+        scope: An explicit ``InjectableScope`` to route this resolution into.
+            The scope is applied to this call's dependency resolution within
+            the current event loop task (its lifecycle is owned by the
+            caller — this does not enter or close the scope). The ContextVar
+            is set for the duration of the awaited call and reset in a
+            ``finally`` block so it never leaks to the caller. Defaults to
+            ``None`` (use the active scope or global manager).
 
     Returns:
         The first value yielded/returned by the dependency function after injection.
@@ -367,6 +398,13 @@ async def async_get_injected_obj(
     # Use async version to trigger async_wrapper path in injectable decorator
     wrapped_func = _create_async_depends_function(func)
     injectable_func = injectable(wrapped_func, use_cache=use_cache)
+    if scope is not None:
+        token = _current_scope.set(scope)
+        try:
+            coro = cast("Callable[..., Awaitable[T]]", injectable_func)()
+            return await coro
+        finally:
+            _current_scope.reset(token)
     coro = cast("Callable[..., Awaitable[T]]", injectable_func)()
     return await coro
 

--- a/test/test_scope.py
+++ b/test/test_scope.py
@@ -77,3 +77,51 @@ async def test_resolution_inside_scope_cleans_up_on_exit_and_skips_global_manage
         assert len(async_exit_stack_manager._stacks) == 0
 
     assert mayor._is_cleaned_up is True
+
+
+import asyncio  # noqa: E402
+
+
+async def test_parallel_scopes_clean_up_independently() -> None:
+    opened: dict[str, Mayor] = {}
+    proceed: dict[str, asyncio.Event] = {"a": asyncio.Event(), "b": asyncio.Event()}
+    done: dict[str, asyncio.Event] = {"a": asyncio.Event(), "b": asyncio.Event()}
+    both_open = asyncio.Event()
+
+    async def get_mayor() -> AsyncGenerator[Mayor, None]:
+        mayor = Mayor()
+        yield mayor
+        mayor.cleanup()
+
+    async def process(name: str) -> None:
+        async with injectable_scope():
+            mayor = await async_get_injected_obj(get_mayor)
+            opened[name] = mayor
+            if len(opened) == 2:
+                both_open.set()
+            await proceed[name].wait()
+        done[name].set()  # scope fully closed here
+
+    task_a = asyncio.create_task(process("a"))
+    task_b = asyncio.create_task(process("b"))
+    try:
+        await both_open.wait()
+        assert opened["a"]._is_cleaned_up is False
+        assert opened["b"]._is_cleaned_up is False
+        assert opened["a"] is not opened["b"]  # isolated caches -> distinct instances
+
+        # Let A finish and tear down; B must be unaffected.
+        proceed["a"].set()
+        await done["a"].wait()
+        assert opened["a"]._is_cleaned_up is True
+        assert opened["b"]._is_cleaned_up is False  # <- isolation proven
+
+        proceed["b"].set()
+        await asyncio.gather(task_a, task_b)
+    finally:
+        for task in (task_a, task_b):
+            if not task.done():
+                task.cancel()
+
+    assert opened["a"]._is_cleaned_up is True
+    assert opened["b"]._is_cleaned_up is True

--- a/test/test_scope.py
+++ b/test/test_scope.py
@@ -1,0 +1,52 @@
+from collections.abc import AsyncGenerator
+from contextlib import AsyncExitStack
+
+import pytest
+
+from fastapi_injectable.scope import InjectableScope, _current_scope, injectable_scope
+from fastapi_injectable.util import cleanup_all_exit_stacks
+
+
+@pytest.fixture(autouse=True)
+async def _clean_global_stacks() -> AsyncGenerator[None, None]:
+    await cleanup_all_exit_stacks()
+    yield
+    await cleanup_all_exit_stacks()
+
+
+async def test_injectable_scope_sets_and_resets_active_scope() -> None:
+    assert _current_scope.get() is None
+    async with injectable_scope() as scope:
+        assert isinstance(scope, InjectableScope)
+        assert _current_scope.get() is scope
+    assert _current_scope.get() is None
+
+
+async def test_scope_exposes_exit_stack_and_cache() -> None:
+    scope = InjectableScope()
+    assert isinstance(scope.exit_stack, AsyncExitStack)
+    assert scope.get_cache() == {}
+
+    no_cache = InjectableScope(use_cache=False)
+    assert no_cache.get_cache() is None
+
+
+async def test_nested_injectable_scope_restores_outer() -> None:
+    async with injectable_scope() as outer:
+        assert _current_scope.get() is outer
+        async with injectable_scope() as inner:
+            assert _current_scope.get() is inner
+        assert _current_scope.get() is outer
+    assert _current_scope.get() is None
+
+
+async def test_injectable_scope_resets_contextvar_on_exception() -> None:
+    async def _raise_inside_scope() -> None:
+        async with injectable_scope():
+            assert _current_scope.get() is not None
+            msg = "boom"
+            raise ValueError(msg)
+
+    with pytest.raises(ValueError, match="boom"):
+        await _raise_inside_scope()
+    assert _current_scope.get() is None

--- a/test/test_scope.py
+++ b/test/test_scope.py
@@ -50,3 +50,30 @@ async def test_injectable_scope_resets_contextvar_on_exception() -> None:
     with pytest.raises(ValueError, match="boom"):
         await _raise_inside_scope()
     assert _current_scope.get() is None
+
+
+from fastapi_injectable.async_exit_stack import async_exit_stack_manager  # noqa: E402
+from fastapi_injectable.util import async_get_injected_obj  # noqa: E402
+
+
+class Mayor:
+    def __init__(self) -> None:
+        self._is_cleaned_up = False
+
+    def cleanup(self) -> None:
+        self._is_cleaned_up = True
+
+
+async def test_resolution_inside_scope_cleans_up_on_exit_and_skips_global_manager() -> None:
+    async def get_mayor() -> AsyncGenerator[Mayor, None]:
+        mayor = Mayor()
+        yield mayor
+        mayor.cleanup()
+
+    async with injectable_scope():
+        mayor = await async_get_injected_obj(get_mayor)
+        assert mayor._is_cleaned_up is False
+        # nothing leaks into the global, function-keyed manager
+        assert len(async_exit_stack_manager._stacks) == 0
+
+    assert mayor._is_cleaned_up is True

--- a/test/test_scope.py
+++ b/test/test_scope.py
@@ -190,3 +190,22 @@ async def test_scope_use_cache_false_disables_dedup() -> None:
         a = await async_get_injected_obj(get_capital_a, use_cache=False)
         b = await async_get_injected_obj(get_capital_b, use_cache=False)
         assert a.mayor is not b.mayor  # no cache → distinct Mayors
+
+
+async def test_explicit_scope_routes_resolution_without_owning_lifecycle() -> None:
+    async def get_mayor() -> AsyncGenerator[Mayor, None]:
+        mayor = Mayor()
+        yield mayor
+        mayor.cleanup()
+
+    scope = InjectableScope()
+    assert _current_scope.get() is None
+
+    # Manage the scope's stack lifecycle by hand (do NOT enter it as the active
+    # scope); route a single resolution into it with scope=.
+    async with scope.exit_stack:
+        mayor = await async_get_injected_obj(get_mayor, scope=scope)
+        assert _current_scope.get() is None  # scope= must not leak the ContextVar
+        assert mayor._is_cleaned_up is False
+
+    assert mayor._is_cleaned_up is True  # cleaned only when WE closed the stack

--- a/test/test_scope.py
+++ b/test/test_scope.py
@@ -52,6 +52,10 @@ async def test_injectable_scope_resets_contextvar_on_exception() -> None:
     assert _current_scope.get() is None
 
 
+from typing import Annotated  # noqa: E402
+
+from fastapi import Depends  # noqa: E402
+
 from fastapi_injectable.async_exit_stack import async_exit_stack_manager  # noqa: E402
 from fastapi_injectable.util import async_get_injected_obj  # noqa: E402
 
@@ -125,3 +129,64 @@ async def test_parallel_scopes_clean_up_independently() -> None:
 
     assert opened["a"]._is_cleaned_up is True
     assert opened["b"]._is_cleaned_up is True
+
+
+class Capital:
+    def __init__(self, mayor: Mayor) -> None:
+        self.mayor = mayor
+
+
+async def test_nested_scopes_clean_up_in_lifo_order() -> None:
+    async def get_mayor() -> AsyncGenerator[Mayor, None]:
+        mayor = Mayor()
+        yield mayor
+        mayor.cleanup()
+
+    async with injectable_scope():
+        outer_mayor = await async_get_injected_obj(get_mayor)
+        async with injectable_scope():
+            inner_mayor = await async_get_injected_obj(get_mayor)
+            assert inner_mayor is not outer_mayor
+            assert inner_mayor._is_cleaned_up is False
+            assert outer_mayor._is_cleaned_up is False
+        # inner scope closed
+        assert inner_mayor._is_cleaned_up is True
+        assert outer_mayor._is_cleaned_up is False
+    assert outer_mayor._is_cleaned_up is True
+
+
+async def test_in_scope_cache_dedups_shared_subdependency() -> None:
+    async def get_mayor() -> AsyncGenerator[Mayor, None]:
+        yield Mayor()
+
+    async def get_capital_a(mayor: Annotated[Mayor, Depends(get_mayor)]) -> Capital:
+        return Capital(mayor)
+
+    async def get_capital_b(mayor: Annotated[Mayor, Depends(get_mayor)]) -> Capital:
+        return Capital(mayor)
+
+    async with injectable_scope():
+        a = await async_get_injected_obj(get_capital_a)
+        b = await async_get_injected_obj(get_capital_b)
+        assert a.mayor is b.mayor  # same scope → shared cache → one Mayor
+        first_mayor = a.mayor
+
+    async with injectable_scope():
+        c = await async_get_injected_obj(get_capital_a)
+        assert c.mayor is not first_mayor  # different scope → fresh cache
+
+
+async def test_scope_use_cache_false_disables_dedup() -> None:
+    async def get_mayor() -> AsyncGenerator[Mayor, None]:
+        yield Mayor()
+
+    async def get_capital_a(mayor: Annotated[Mayor, Depends(get_mayor)]) -> Capital:
+        return Capital(mayor)
+
+    async def get_capital_b(mayor: Annotated[Mayor, Depends(get_mayor)]) -> Capital:
+        return Capital(mayor)
+
+    async with injectable_scope(use_cache=False):
+        a = await async_get_injected_obj(get_capital_a, use_cache=False)
+        b = await async_get_injected_obj(get_capital_b, use_cache=False)
+        assert a.mayor is not b.mayor  # no cache → distinct Mayors

--- a/test/test_scope.py
+++ b/test/test_scope.py
@@ -1,10 +1,16 @@
-from collections.abc import AsyncGenerator
+import asyncio
+from collections.abc import AsyncGenerator, Generator
 from contextlib import AsyncExitStack
+from typing import Annotated
 
 import pytest
+from fastapi import Depends
 
+from fastapi_injectable.async_exit_stack import async_exit_stack_manager
+from fastapi_injectable.concurrency import run_coroutine_sync
+from fastapi_injectable.decorator import injectable
 from fastapi_injectable.scope import InjectableScope, _current_scope, injectable_scope
-from fastapi_injectable.util import cleanup_all_exit_stacks
+from fastapi_injectable.util import async_get_injected_obj, cleanup_all_exit_stacks, get_injected_obj
 
 
 @pytest.fixture(autouse=True)
@@ -52,15 +58,6 @@ async def test_injectable_scope_resets_contextvar_on_exception() -> None:
     assert _current_scope.get() is None
 
 
-from typing import Annotated  # noqa: E402
-
-from fastapi import Depends  # noqa: E402
-
-from fastapi_injectable.async_exit_stack import async_exit_stack_manager  # noqa: E402
-from fastapi_injectable.decorator import injectable  # noqa: E402
-from fastapi_injectable.util import async_get_injected_obj  # noqa: E402
-
-
 class Mayor:
     def __init__(self) -> None:
         self._is_cleaned_up = False
@@ -82,9 +79,6 @@ async def test_resolution_inside_scope_cleans_up_on_exit_and_skips_global_manage
         assert len(async_exit_stack_manager._stacks) == 0
 
     assert mayor._is_cleaned_up is True
-
-
-import asyncio  # noqa: E402
 
 
 async def test_parallel_scopes_clean_up_independently() -> None:
@@ -294,3 +288,28 @@ async def test_no_scope_falls_back_to_global_manager() -> None:
 
     await cleanup_exit_stack_of_func(get_mayor)
     assert mayor._is_cleaned_up is True
+
+
+def test_get_injected_obj_explicit_scope_sync() -> None:
+    class Thing:
+        def __init__(self) -> None:
+            self.cleaned = False
+
+    def get_thing() -> Generator[Thing, None, None]:
+        thing = Thing()
+        yield thing
+        thing.cleaned = True
+
+    scope = InjectableScope()
+    thing = get_injected_obj(get_thing, scope=scope)  # routes cleanup onto scope's exit_stack
+    assert thing.cleaned is False
+    run_coroutine_sync(scope.exit_stack.aclose())  # caller closes the scope's stack
+    assert thing.cleaned is True
+
+
+async def test_injectable_scope_aexit_with_no_prior_aenter() -> None:
+    # Cover the defensive branch: __aexit__ when _token is None (never __aenter__'d).
+    scope = InjectableScope()
+    assert scope._token is None  # never entered
+    # Should not raise and should close the exit stack cleanly.
+    await scope.__aexit__(None, None, None)

--- a/test/test_scope.py
+++ b/test/test_scope.py
@@ -209,3 +209,14 @@ async def test_explicit_scope_routes_resolution_without_owning_lifecycle() -> No
         assert mayor._is_cleaned_up is False
 
     assert mayor._is_cleaned_up is True  # cleaned only when WE closed the stack
+
+
+def test_public_api_exports_scope_symbols() -> None:
+    import fastapi_injectable
+    from fastapi_injectable import InjectableScope as ExportedScope
+    from fastapi_injectable import injectable_scope as exported_factory
+
+    assert "InjectableScope" in fastapi_injectable.__all__
+    assert "injectable_scope" in fastapi_injectable.__all__
+    assert ExportedScope is InjectableScope
+    assert exported_factory is injectable_scope

--- a/test/test_scope.py
+++ b/test/test_scope.py
@@ -113,7 +113,7 @@ async def test_parallel_scopes_clean_up_independently() -> None:
         proceed["a"].set()
         await done["a"].wait()
         assert opened["a"]._is_cleaned_up is True
-        assert opened["b"]._is_cleaned_up is False  # <- isolation proven
+        assert opened["b"]._is_cleaned_up is False  # type: ignore[unreachable]  # isolation proven
 
         proceed["b"].set()
         await asyncio.gather(task_a, task_b)
@@ -122,7 +122,7 @@ async def test_parallel_scopes_clean_up_independently() -> None:
             if not task.done():
                 task.cancel()
 
-    assert opened["a"]._is_cleaned_up is True
+    assert opened["a"]._is_cleaned_up is True  # type: ignore[unreachable]
     assert opened["b"]._is_cleaned_up is True
 
 
@@ -146,8 +146,8 @@ async def test_nested_scopes_clean_up_in_lifo_order() -> None:
             assert outer_mayor._is_cleaned_up is False
         # inner scope closed
         assert inner_mayor._is_cleaned_up is True
-        assert outer_mayor._is_cleaned_up is False
-    assert outer_mayor._is_cleaned_up is True
+        assert outer_mayor._is_cleaned_up is False  # type: ignore[unreachable]
+    assert outer_mayor._is_cleaned_up is True  # type: ignore[unreachable]
 
 
 async def test_in_scope_cache_dedups_shared_subdependency() -> None:
@@ -267,7 +267,7 @@ async def test_injectable_decorated_function_uses_active_scope() -> None:
         return mayor
 
     async with injectable_scope():
-        captured["m"] = await handler()
+        captured["m"] = await handler()  # type: ignore[call-arg]
         assert captured["m"]._is_cleaned_up is False
         assert len(async_exit_stack_manager._stacks) == 0  # nothing leaked into the global manager
 

--- a/test/test_scope.py
+++ b/test/test_scope.py
@@ -57,6 +57,7 @@ from typing import Annotated  # noqa: E402
 from fastapi import Depends  # noqa: E402
 
 from fastapi_injectable.async_exit_stack import async_exit_stack_manager  # noqa: E402
+from fastapi_injectable.decorator import injectable  # noqa: E402
 from fastapi_injectable.util import async_get_injected_obj  # noqa: E402
 
 
@@ -220,3 +221,76 @@ def test_public_api_exports_scope_symbols() -> None:
     assert "injectable_scope" in fastapi_injectable.__all__
     assert ExportedScope is InjectableScope
     assert exported_factory is injectable_scope
+
+
+async def test_exception_inside_scope_still_cleans_up() -> None:
+    captured: dict[str, Mayor] = {}
+
+    async def get_mayor() -> AsyncGenerator[Mayor, None]:
+        mayor = Mayor()
+        yield mayor
+        mayor.cleanup()
+
+    with pytest.raises(ValueError, match="boom"):  # noqa: PT012
+        async with injectable_scope():
+            captured["m"] = await async_get_injected_obj(get_mayor)
+            assert captured["m"]._is_cleaned_up is False
+            msg = "boom"
+            raise ValueError(msg)
+
+    assert captured["m"]._is_cleaned_up is True
+    assert _current_scope.get() is None
+
+
+async def test_custom_callback_rides_scope_lifecycle_in_lifo_order() -> None:
+    order: list[str] = []
+
+    async def get_mayor() -> AsyncGenerator[Mayor, None]:
+        mayor = Mayor()
+        yield mayor
+        order.append("dependency")
+
+    async def my_cleanup() -> None:
+        order.append("callback")
+
+    async with injectable_scope() as scope:
+        await async_get_injected_obj(get_mayor)  # registers dependency cleanup first
+        scope.exit_stack.push_async_callback(my_cleanup)  # pushed last → runs first
+
+    assert order == ["callback", "dependency"]
+
+
+async def test_injectable_decorated_function_uses_active_scope() -> None:
+    captured: dict[str, Mayor] = {}
+
+    async def get_mayor() -> AsyncGenerator[Mayor, None]:
+        mayor = Mayor()
+        yield mayor
+        mayor.cleanup()
+
+    @injectable
+    async def handler(mayor: Annotated[Mayor, Depends(get_mayor)]) -> Mayor:
+        return mayor
+
+    async with injectable_scope():
+        captured["m"] = await handler()
+        assert captured["m"]._is_cleaned_up is False
+        assert len(async_exit_stack_manager._stacks) == 0  # nothing leaked into the global manager
+
+    assert captured["m"]._is_cleaned_up is True
+
+
+async def test_no_scope_falls_back_to_global_manager() -> None:
+    from fastapi_injectable.util import cleanup_exit_stack_of_func
+
+    async def get_mayor() -> AsyncGenerator[Mayor, None]:
+        mayor = Mayor()
+        yield mayor
+        mayor.cleanup()
+
+    mayor = await async_get_injected_obj(get_mayor)
+    assert mayor._is_cleaned_up is False
+    assert len(async_exit_stack_manager._stacks) >= 1  # registered globally as before
+
+    await cleanup_exit_stack_of_func(get_mayor)
+    assert mayor._is_cleaned_up is True


### PR DESCRIPTION
## Summary

Resolves the per-task cleanup problem raised in [discussion #229](https://github.com/JasperSui/fastapi-injectable/discussions/229): dependency exit stacks are keyed by **callable**, so concurrent invocations of the same injectable share one stack — and tearing down one parallel event's resources disposes another's still-in-use resources.

This adds an opt-in, `contextvars`-based **scope** that gives each unit of async work its own isolated dependency exit stack **and** cache — the same request-scoped model FastAPI uses internally.

## API

```python
import asyncio
from fastapi_injectable import async_get_injected_obj, injectable_scope

async def process_event(event):
    async with injectable_scope():
        conn = await async_get_injected_obj(get_connection)
        await handle(event, conn)
    # only this event's connection is closed here — siblings are untouched

async def consume(events):
    async with asyncio.TaskGroup() as tg:   # 3.11+; use asyncio.gather() on 3.10
        for event in events:
            tg.create_task(process_event(event))
```

Each task enters its own scope, so `contextvars` keeps them isolated — tearing down one scope never touches another.

New public surface:
- **`injectable_scope(*, use_cache=True)`** — async context manager yielding an `InjectableScope`.
- **`InjectableScope`** — also usable directly (`async with InjectableScope() as scope:`); exposes `.exit_stack` so you can push your own cleanup onto the same lifecycle.
- **`async_get_injected_obj(..., scope=...)`** / **`get_injected_obj(..., scope=...)`** — route a single resolution into a caller-managed scope (does not enter or close it; the caller owns its lifecycle).

## How it works

`resolve_dependencies` checks a `ContextVar` for an active scope: if present, it uses the scope's exit stack + cache; otherwise it falls back to the existing global, function-keyed manager. The cache and exit-stack lifetime are coupled within a scope (like FastAPI's request scope), which avoids the stale-resource footgun of caching a value globally while its cleanup runs on a per-scope stack.

## Backward compatibility

- With **no active scope**, behavior is byte-for-byte identical to before (the global manager + `cleanup_*` helpers work exactly as today).
- The only signature change is a new **keyword-only, defaulted** `scope=` on the two injection entry points.

## Limitations

- **Async-first.** Under the `background_thread` loop strategy, `contextvars` are not propagated across threads, so a scope is not visible inside the background loop. Documented in the README and the `get_injected_obj` docstring.

## Tests

- 17 new tests in `test/test_scope.py`: parallel-task isolation, nested scopes (LIFO), per-scope cache dedup, `use_cache=False`, exception cleanup, explicit `scope=`, custom-callback lifecycle, `@injectable` decorator-path routing, and a no-scope regression test.
- All Python 3.10-compatible (the parallel test uses `asyncio.create_task` + `gather`, not `TaskGroup`).
- Full suite: **165 passed**, **100% coverage** (`fail_under = 100`), ruff + mypy clean.

## Docs

The README "Advanced Scenarios" section gains an "Isolated dependency scopes for parallel work" subsection; `injectable_scope` / `InjectableScope` are auto-documented via the existing `automodule` reference page.
