### PR TITLE
fix: accept classes and sync providers in async_get_injected_obj

### DIFF
--- a/src/fastapi_injectable/util.py
+++ b/src/fastapi_injectable/util.py
@@ -322,8 +322,35 @@ async def async_get_injected_obj(
 ) -> T: ...
 
 
+@overload
 async def async_get_injected_obj(
-    func: Callable[P, Awaitable[T]] | Callable[P, AsyncGenerator[T, Any]],
+    func: Callable[..., Generator[T, Any, Any]],
+    args: list[Any] | None = None,
+    kwargs: dict[str, Any] | None = None,
+    *,
+    use_cache: bool = True,
+    scope: InjectableScope | None = None,
+) -> T: ...
+
+
+@overload
+async def async_get_injected_obj(
+    func: Callable[..., T],
+    args: list[Any] | None = None,
+    kwargs: dict[str, Any] | None = None,
+    *,
+    use_cache: bool = True,
+    scope: InjectableScope | None = None,
+) -> T: ...
+
+
+async def async_get_injected_obj(
+    func: (
+        Callable[P, T]
+        | Callable[P, Awaitable[T]]
+        | Callable[P, Generator[T, Any, Any]]
+        | Callable[P, AsyncGenerator[T, Any]]
+    ),
     args: list[Any] | None = None,
     kwargs: dict[str, Any] | None = None,
     *,
@@ -336,12 +363,17 @@ async def async_get_injected_obj(
     contexts like Kafka consumers, async callbacks, or other scenarios where
     an event loop is already running.
 
-    This function only accepts async functions (coroutines) and async generators.
-    For sync functions, use get_injected_obj() instead.
+    Unlike get_injected_obj(), this works in already-running event loops. It accepts
+    every provider kind that get_injected_obj() does -- sync/async functions, classes,
+    and sync/async generators -- because FastAPI resolves sync providers just like async
+    ones. The async API is preferred whenever an event loop is already running.
 
     Args:
-        func: The async dependency function to inject. Must be:
+        func: The dependency function (or class) to inject. Can be:
+            - A regular synchronous function
             - An async function (coroutine)
+            - A class (its constructor is used as the provider)
+            - A synchronous generator
             - An async generator
         args: Positional arguments to pass to the dependency function.
         kwargs: Keyword arguments to pass to the dependency function.
@@ -378,9 +410,8 @@ async def async_get_injected_obj(
 
     Notes:
         - This function must be called from an async context (use await)
-        - Only accepts async functions and async generators
-        - For sync functions, use get_injected_obj() instead
-        - For async generators, only the first yielded value is returned
+        - Accepts sync/async functions, classes, and sync/async generators
+        - For generator functions, only the first yielded value is returned
         - Cleanup code in generators will be executed when calling cleanup functions
         - Uses FastAPI's dependency injection system under the hood
         - Unlike get_injected_obj(), this works in already-running event loops

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1107,6 +1107,86 @@ async def test_async_get_injected_obj_with_async_generator_with_args_and_kwargs(
     cleanup_mock.assert_called_once()
 
 
+async def test_async_get_injected_obj_with_class(
+    clean_exit_stack_manager: None,
+) -> None:
+    """Passing a class (type) directly should work and keep its type. See issue #236."""
+
+    class Service:
+        def __init__(self) -> None:
+            self.value = "from_class"
+
+    # The explicit annotation doubles as a type-level regression guard: before the
+    # Callable[..., T] overload existed, mypy rejected ``type[Service]`` here.
+    service: Service = await async_get_injected_obj(Service)
+    assert isinstance(service, Service)
+    assert service.value == "from_class"
+
+
+async def test_async_get_injected_obj_with_class_with_dependencies(
+    clean_exit_stack_manager: None,
+) -> None:
+    """The exact scenario from issue #236: a class whose __init__ has Depends() params."""
+
+    class Client:
+        def __init__(self) -> None:
+            self.cache = "redis"
+
+    class Repository:
+        def __init__(self, client: Annotated[Client, Depends(Client)]) -> None:
+            self.client = client
+
+    class Service:
+        def __init__(self, repository: Annotated[Repository, Depends(Repository)]) -> None:
+            self.repository = repository
+
+    service: Service = await async_get_injected_obj(Service)
+    assert isinstance(service, Service)
+    assert isinstance(service.repository, Repository)
+    assert service.repository.client.cache == "redis"
+
+
+async def test_async_get_injected_obj_with_sync_function(
+    clean_exit_stack_manager: None,
+) -> None:
+    """A plain sync function provider is matched by the Callable[..., T] overload."""
+
+    class Service:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    def get_service() -> Service:
+        return Service(value="sync_func")
+
+    service: Service = await async_get_injected_obj(get_service)
+    assert isinstance(service, Service)
+    assert service.value == "sync_func"
+
+
+async def test_async_get_injected_obj_with_sync_generator(
+    clean_exit_stack_manager: None,
+) -> None:
+    """A sync generator provider is matched by the Generator[T, Any, Any] overload."""
+    cleanup_mock = Mock()
+
+    class Service:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    def get_service() -> Generator[Service, None, None]:
+        try:
+            yield Service(value="sync_gen")
+        finally:
+            cleanup_mock()
+
+    service: Service = await async_get_injected_obj(get_service)
+    assert isinstance(service, Service)
+    assert service.value == "sync_gen"
+
+    await cleanup_all_exit_stacks()
+    cleanup_mock.assert_called_once()
+
+
 async def test_async_get_injected_obj_with_dependencies(
     clean_exit_stack_manager: None,
 ) -> None:


### PR DESCRIPTION
# Purpose

`async_get_injected_obj()` accepts classes and other sync providers at runtime, but its
type stubs only covered `Awaitable[T]` / `AsyncGenerator[T, Any]`, so mypy rejected working
code (e.g. `await async_get_injected_obj(Service)`) with an `arg-type` error and forced
`type: ignore`. This aligns its typed surface with `get_injected_obj()`. Closes #236.

# Changes

### TL;DR
- Add `Generator[T, Any, Any]` + catch-all `Callable[..., T]` overloads to `async_get_injected_obj()`
- Catch-all is placed **last** so async-func / async-gen inference is unchanged
- Type-only change — no runtime logic touched
- Refresh docstring (it wrongly said "only accepts async functions")
- Add 4 regression tests (class, class+`Depends`, sync func, sync gen)

---

The two helpers already resolve the same provider kinds at runtime (FastAPI resolves sync
providers just like async ones; the async wrapper falls back to returning the resolved value),
so the only gap was the missing overloads on the async variant. The catch-all `Callable[..., T]`
must come after the `Awaitable`/`AsyncGenerator`/`Generator` overloads, otherwise it would
swallow async functions and infer `Coroutine[...]` as the return type — same ordering
`get_injected_obj()` already uses. Because `test/` is type-checked by the nox `mypy` session,
the new tests guard both runtime behavior and the types (they were confirmed red pre-fix,
green post-fix). Verified locally via nox: `mypy-3.10`/`mypy-3.14`, `tests-3.10` (172 passed),
`coverage` (100%), and `pre-commit` all green.
