### PR TITLE
fix: make setup_graceful_shutdown terminate and chain signal handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,7 +582,26 @@ setup_graceful_shutdown(
     signals=[signal.SIGTERM],
     raise_exception=True
 )
+
+# Option #4: Only register the atexit cleanup, without installing OS signal handlers
+# (useful when a framework already owns SIGTERM/SIGINT, or when calling off the main thread)
+setup_graceful_shutdown(install_signal_handlers=False)
 ```
+
+**How the signal handler behaves:**
+
+- **It still terminates the process.** After running cleanup, the handler re-raises termination so
+  your process exits as usual: `SIGINT` raises `KeyboardInterrupt` and any other signal (e.g. `SIGTERM`)
+  raises `SystemExit(0)`. This means an orchestrator's `SIGTERM` (Kubernetes, systemd) and `Ctrl-C` keep
+  working — cleanup runs *and then* the process exits, instead of hanging until `SIGKILL`.
+- **It chains your existing handler.** If you already installed a handler for one of these signals,
+  it is captured and invoked after cleanup, so your own shutdown logic (flush metrics, finish in-flight
+  work, close connections) is preserved rather than silently overwritten. `SIG_DFL`/`SIG_IGN` are left
+  alone.
+- **It must run on the main thread.** Python only allows `signal.signal()` to be called from the main
+  thread of the main interpreter. If you call `setup_graceful_shutdown()` from another thread, signal
+  registration is skipped with a warning and only the `atexit` cleanup is registered — it will **not**
+  raise `ValueError`. Pass `install_signal_handlers=False` to opt out of signal handling explicitly.
 
 
 ### App Registration for State Access

--- a/src/fastapi_injectable/util.py
+++ b/src/fastapi_injectable/util.py
@@ -1,8 +1,10 @@
 import atexit
 import inspect
 import signal
+import threading
 from collections.abc import AsyncGenerator, Awaitable, Callable, Generator, Sequence
 from functools import partial
+from types import FrameType
 from typing import Annotated, Any, ParamSpec, TypeVar, cast, get_type_hints, overload
 
 from fastapi import Depends
@@ -11,11 +13,15 @@ from .async_exit_stack import async_exit_stack_manager
 from .cache import dependency_cache
 from .concurrency import run_coroutine_sync
 from .decorator import injectable
+from .logging import logger
 from .scope import InjectableScope, _current_scope
 
 T = TypeVar("T")
 T2 = TypeVar("T2")
 P = ParamSpec("P")
+
+# Signature of a Python-level OS signal handler, as accepted by ``signal.signal``.
+_SignalHandler = Callable[[int, FrameType | None], Any]
 
 PROVIDER_TO_WRAPPER_FUNC_MAP: dict[Callable[..., Any], list[Callable[[Any], Any]]] = {}
 
@@ -486,7 +492,12 @@ async def clear_dependency_cache() -> None:
     await dependency_cache.clear()
 
 
-def setup_graceful_shutdown(signals: Sequence[signal.Signals] | None = None, *, raise_exception: bool = False) -> None:
+def setup_graceful_shutdown(
+    signals: Sequence[signal.Signals] | None = None,
+    *,
+    raise_exception: bool = False,
+    install_signal_handlers: bool = True,
+) -> None:
     """Register handlers to perform cleanup during application shutdown.
 
     Args:
@@ -494,11 +505,25 @@ def setup_graceful_shutdown(signals: Sequence[signal.Signals] | None = None, *, 
                  Defaults to [SIGINT, SIGTERM].
         raise_exception: Whether to raise exceptions during cleanup.
             If False, exceptions are logged as warnings. Defaults to False.
+        install_signal_handlers: Whether to install OS signal handlers for ``signals``.
+            When False, only the ``atexit`` cleanup is registered (useful when embedding
+            in a framework that owns signal handling, or when running off the main thread).
+            Defaults to True.
 
     Notes:
-        - When a registered signal is received, this function ensures that all resources
-          (e.g., exit stacks) are properly released before the application exits.
-        - Also registers a cleanup routine via `atexit` to handle unexpected shutdown scenarios.
+        - When a registered signal is received, the handler runs cleanup, invokes any
+          handler that was already installed for that signal (so your own shutdown logic
+          is chained, not overwritten), and then propagates termination: ``SIGINT`` raises
+          ``KeyboardInterrupt`` and every other signal raises ``SystemExit(0)``. This means
+          the process still terminates on ``SIGTERM``/``SIGINT`` after cleanup, exactly as
+          it would without this helper installed.
+        - A cleanup routine is also registered via ``atexit`` so resources are released on
+          normal interpreter exit.
+        - ``signal.signal()`` may only be called from the main thread of the main
+          interpreter. When called from another thread, signal-handler registration is
+          skipped with a warning and only the ``atexit`` cleanup is registered; the
+          function never raises ``ValueError`` in that case. Pass
+          ``install_signal_handlers=False`` to skip signal handling explicitly.
 
     Raises:
         DependencyCleanupError: When cleanup fails and raise_exception is True
@@ -506,9 +531,41 @@ def setup_graceful_shutdown(signals: Sequence[signal.Signals] | None = None, *, 
     if signals is None:
         signals = [signal.SIGINT, signal.SIGTERM]
 
-    def sync_cleanup(*_: Any) -> None:  # noqa: ANN401
+    def run_cleanup() -> None:
         run_coroutine_sync(cleanup_all_exit_stacks(raise_exception=raise_exception))
 
-    atexit.register(sync_cleanup)
+    # Always clean up on normal interpreter exit, regardless of signal handling.
+    atexit.register(run_cleanup)
+
+    if not install_signal_handlers:
+        return
+
+    # signal.signal() only works in the main thread of the main interpreter; calling it
+    # elsewhere raises ValueError. Degrade gracefully instead of crashing at startup.
+    if threading.current_thread() is not threading.main_thread():
+        logger.warning(
+            "setup_graceful_shutdown() can only install OS signal handlers from the main "
+            "thread of the main interpreter; skipping signal registration (atexit cleanup "
+            "is still active). Call it from the main thread, or pass "
+            "install_signal_handlers=False to silence this warning.",
+        )
+        return
+
+    def build_handler(target_signal: signal.Signals, previous_handler: _SignalHandler | int | None) -> _SignalHandler:
+        def handler(signum: int, frame: FrameType | None) -> None:
+            run_cleanup()
+            # Chain the handler that was installed before us instead of clobbering it.
+            # SIG_DFL/SIG_IGN (and an unset handler) are not callable, so they are skipped.
+            if callable(previous_handler):
+                previous_handler(signum, frame)
+            # Restore the default "terminate" disposition we replaced so the process still
+            # exits: SIGINT raises KeyboardInterrupt, anything else raises SystemExit.
+            if target_signal == signal.SIGINT:
+                raise KeyboardInterrupt
+            raise SystemExit(0)
+
+        return handler
+
     for sig in signals:
-        signal.signal(sig, sync_cleanup)
+        previous_handler = signal.getsignal(sig)
+        signal.signal(sig, build_handler(sig, previous_handler))

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,5 +1,10 @@
+import logging
 import signal
+import subprocess
+import sys
+import threading
 from collections.abc import AsyncGenerator, Generator
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -72,8 +77,9 @@ def test_setup_graceful_shutdown(mock_run_coroutine_sync: Mock) -> None:
 
             mock_register.assert_called_once()
             assert mock_signal.call_count == 2  # SIGINT and SIGTERM
-            mock_signal.assert_any_call(signal.SIGINT, mock_register.call_args[0][0])
-            mock_signal.assert_any_call(signal.SIGTERM, mock_register.call_args[0][0])
+            registered_signals = [call.args[0] for call in mock_signal.call_args_list]
+            assert signal.SIGINT in registered_signals
+            assert signal.SIGTERM in registered_signals
 
 
 def test_setup_graceful_shutdown_custom_signals(mock_run_coroutine_sync: Mock) -> None:
@@ -85,7 +91,8 @@ def test_setup_graceful_shutdown_custom_signals(mock_run_coroutine_sync: Mock) -
 
             mock_register.assert_called_once()
             assert mock_signal.call_count == 1
-            mock_signal.assert_any_call(signal.SIGINT, mock_register.call_args[0][0])
+            registered_signals = [call.args[0] for call in mock_signal.call_args_list]
+            assert signal.SIGINT in registered_signals
 
 
 async def test_setup_graceful_shutdown_handler_called(
@@ -110,3 +117,140 @@ async def test_setup_graceful_shutdown_handler_called(
             await cleanup_coro
 
             assert cleanup_coro.__name__ == "cleanup_all_exit_stacks"
+
+
+def test_setup_graceful_shutdown_sigterm_handler_terminates(mock_run_coroutine_sync: Mock) -> None:
+    with (
+        patch("src.fastapi_injectable.util.atexit.register"),
+        patch("src.fastapi_injectable.util.signal.getsignal", return_value=signal.SIG_DFL),
+        patch("src.fastapi_injectable.util.signal.signal") as mock_signal,
+    ):
+        setup_graceful_shutdown(signals=[signal.SIGTERM])
+
+    # The handler installed for the signal (second positional arg of signal.signal).
+    handler = mock_signal.call_args_list[0].args[1]
+
+    with pytest.raises(SystemExit) as exc_info:
+        handler(signal.SIGTERM, None)
+
+    assert exc_info.value.code == 0
+    mock_run_coroutine_sync.assert_called_once()
+    # Close the (mocked, never-awaited) cleanup coroutine to keep output pristine.
+    mock_run_coroutine_sync.call_args[0][0].close()
+
+
+def test_setup_graceful_shutdown_sigint_handler_terminates(mock_run_coroutine_sync: Mock) -> None:
+    with (
+        patch("src.fastapi_injectable.util.atexit.register"),
+        patch("src.fastapi_injectable.util.signal.getsignal", return_value=signal.SIG_DFL),
+        patch("src.fastapi_injectable.util.signal.signal") as mock_signal,
+    ):
+        setup_graceful_shutdown(signals=[signal.SIGINT])
+
+    handler = mock_signal.call_args_list[0].args[1]
+
+    with pytest.raises(KeyboardInterrupt):
+        handler(signal.SIGINT, None)
+
+    mock_run_coroutine_sync.call_args[0][0].close()
+
+
+def test_setup_graceful_shutdown_chains_previous_handler(mock_run_coroutine_sync: Mock) -> None:
+    previous_handler = Mock()
+
+    with (
+        patch("src.fastapi_injectable.util.atexit.register"),
+        patch("src.fastapi_injectable.util.signal.getsignal", return_value=previous_handler),
+        patch("src.fastapi_injectable.util.signal.signal") as mock_signal,
+    ):
+        setup_graceful_shutdown(signals=[signal.SIGTERM])
+
+    handler = mock_signal.call_args_list[0].args[1]
+
+    with pytest.raises(SystemExit):
+        handler(signal.SIGTERM, None)
+
+    # The pre-existing handler must be invoked, not clobbered.
+    previous_handler.assert_called_once_with(signal.SIGTERM, None)
+    mock_run_coroutine_sync.call_args[0][0].close()
+
+
+def test_setup_graceful_shutdown_skips_signal_handlers_off_main_thread(
+    mock_run_coroutine_sync: Mock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def run_in_thread() -> None:
+        # Do NOT mock signal.signal here: the real main-thread guard must prevent
+        # the call, otherwise CPython raises ValueError off the main thread.
+        with patch("src.fastapi_injectable.util.atexit.register") as mock_register:
+            try:
+                setup_graceful_shutdown(signals=[signal.SIGTERM])
+                captured["error"] = None
+            except Exception as exc:  # noqa: BLE001
+                captured["error"] = exc
+            captured["atexit_called"] = mock_register.called
+
+    with caplog.at_level(logging.WARNING, logger="fastapi_injectable"):
+        thread = threading.Thread(target=run_in_thread)
+        thread.start()
+        thread.join()
+
+    assert captured["error"] is None  # no ValueError off the main thread
+    assert captured["atexit_called"] is True  # atexit cleanup is still registered
+    assert any("main thread" in record.message for record in caplog.records)
+
+
+def test_setup_graceful_shutdown_install_signal_handlers_false(mock_run_coroutine_sync: Mock) -> None:
+    with (
+        patch("src.fastapi_injectable.util.atexit.register") as mock_register,
+        patch("src.fastapi_injectable.util.signal.signal") as mock_signal,
+    ):
+        setup_graceful_shutdown(install_signal_handlers=False)
+
+    mock_register.assert_called_once()  # atexit cleanup still registered
+    mock_signal.assert_not_called()  # but no OS signal handlers installed
+
+
+_TERMINATION_SCRIPT = """
+import os
+import signal
+import sys
+import time
+
+from fastapi_injectable import setup_graceful_shutdown
+
+setup_graceful_shutdown(signals=[signal.{signal_name}])
+os.kill(os.getpid(), signal.{signal_name})
+time.sleep(5)
+sys.stdout.write("STILL ALIVE")
+sys.stdout.flush()
+sys.exit(0)
+"""
+
+
+def test_setup_graceful_shutdown_terminates_process_on_sigterm() -> None:
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", _TERMINATION_SCRIPT.format(signal_name="SIGTERM")],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert "STILL ALIVE" not in result.stdout
+    assert result.returncode == 0  # SystemExit(0) on SIGTERM
+
+
+def test_setup_graceful_shutdown_terminates_process_on_sigint() -> None:
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", _TERMINATION_SCRIPT.format(signal_name="SIGINT")],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert "STILL ALIVE" not in result.stdout
+    assert result.returncode != 0  # uncaught KeyboardInterrupt on SIGINT

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -230,6 +230,18 @@ sys.exit(0)
 """
 
 
+# These end-to-end tests rely on POSIX signal-delivery semantics. On Windows,
+# os.kill() calls TerminateProcess() for SIGTERM/SIGINT, hard-killing the process
+# with the signal number as exit code without ever invoking the Python handler, so
+# they cannot exercise our handler there. The in-process handler tests above cover
+# the same logic (and all of its lines) on every platform.
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX signal-delivery semantics; os.kill() hard-terminates on Windows without running the handler",
+)
+
+
+@_skip_on_windows
 def test_setup_graceful_shutdown_terminates_process_on_sigterm() -> None:
     result = subprocess.run(  # noqa: S603
         [sys.executable, "-c", _TERMINATION_SCRIPT.format(signal_name="SIGTERM")],
@@ -243,6 +255,7 @@ def test_setup_graceful_shutdown_terminates_process_on_sigterm() -> None:
     assert result.returncode == 0  # SystemExit(0) on SIGTERM
 
 
+@_skip_on_windows
 def test_setup_graceful_shutdown_terminates_process_on_sigint() -> None:
     result = subprocess.run(  # noqa: S603
         [sys.executable, "-c", _TERMINATION_SCRIPT.format(signal_name="SIGINT")],


### PR DESCRIPTION
# Purpose
`setup_graceful_shutdown` is the library's recommended shutdown hook for its exact target audience (Celery/Dramatiq workers, cron jobs, long-running CLIs), but it ran cleanup and then *returned* — so signals no longer terminated the process, it overwrote any pre-existing handler, and it crashed off the main thread. This restores the advertised behavior.

# Changes

### TL;DR
- SIGTERM now raises `SystemExit(0)` and SIGINT raises `KeyboardInterrupt` after cleanup — the process actually exits
- Captures and chains the previously-installed signal handler instead of silently clobbering it
- Off-main-thread calls log a warning and register `atexit` only — no more `ValueError`
- New `install_signal_handlers=False` opt-out; docstring + README "Graceful Shutdown" updated
- Tests cover termination (subprocess kill), handler chaining, and off-thread; coverage stays 100%

---

After cleanup, the handler restores the default "terminate" disposition it replaced, so K8s/systemd `SIGTERM` and `Ctrl-C` work again instead of hanging until `SIGKILL`. The prior handler is captured via `signal.getsignal()` before registration and invoked after cleanup when callable (`SIG_DFL`/`SIG_IGN` skipped). `signal.signal()` is only called on the main thread of the main interpreter; otherwise the function degrades to atexit-only cleanup with a warning. Verified locally with `ruff`, `nox -s mypy-3.10`, and `nox -s tests` (179 passed) at 100% coverage, including end-to-end SIGTERM/SIGINT subprocess kill tests. **Risk:** intentional behavior change — the helper now terminates the process on signal (it previously did not), matching the documented contract.
