### PR TITLE
fix(mypy): support @injectable(...) call form and keyword-only deps

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -125,11 +125,12 @@ def tests(session: nox.Session) -> None:
     """Run the test suite."""
     session.install(".")
     session.install("coverage[toml]", "pytest", "pytest-asyncio", "httpx", "celery", "dramatiq")
-    # temporalio contains a native Rust extension and has no wheels for free-threaded Python.
-    # Skip it on those interpreters so pytest.importorskip() can gracefully skip temporal tests.
+    # temporalio bundles a native Rust extension, and mypy ships mypyc-compiled wheels;
+    # neither targets free-threaded Python. Skip both on those interpreters -- the temporal
+    # tests and test_mypy_plugin each use pytest.importorskip() to skip gracefully.
     is_free_threaded = isinstance(session.python, str) and session.python.endswith("t")
     if not is_free_threaded:
-        session.install("temporalio")
+        session.install("temporalio", "mypy")
     try:
         session.run("coverage", "run", "--parallel-mode", "-m", "pytest", *session.posargs)
     finally:

--- a/src/fastapi_injectable/mypy.py
+++ b/src/fastapi_injectable/mypy.py
@@ -20,6 +20,7 @@ from mypy.nodes import (
     ARG_POS,
     ArgKind,
     Argument,
+    CallExpr,
     Decorator,
     Expression,
     FuncDef,
@@ -32,10 +33,19 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-INJECTABLE_DECORATOR_FULLNAMES = {
-    "fastapi_injectable.decorator.injectable",
-    "src.fastapi_injectable.decorator.injectable",
-}
+INJECTABLE_DECORATOR_FULLNAME = "fastapi_injectable.decorator.injectable"
+
+
+def _is_injectable_fullname(fullname: str) -> bool:
+    """Check whether a fully-qualified name refers to fastapi-injectable's ``injectable``.
+
+    The decorator always lives in ``fastapi_injectable.decorator``. When this repository
+    is type-checked in place (an editable / ``src``-layout checkout, e.g. its own test
+    suite imported as ``src.fastapi_injectable``), the same symbol additionally resolves
+    under a ``src.`` prefix, so the canonical suffix is matched too -- rather than shipping
+    the dev-only ``src.`` path inside the installed plugin.
+    """
+    return fullname == INJECTABLE_DECORATOR_FULLNAME or fullname.endswith(f".{INJECTABLE_DECORATOR_FULLNAME}")
 
 
 class FastApiInjectablePlugin(Plugin):
@@ -59,21 +69,32 @@ class FastApiInjectablePlugin(Plugin):
         if not sym_table_node or not isinstance(sym_table_node.node, Decorator):
             return None
 
-        if any(
-            name_expr.fullname in INJECTABLE_DECORATOR_FULLNAMES
-            for name_expr in sym_table_node.node.decorators
-            if isinstance(name_expr, NameExpr)
-        ):
+        if any(self._is_injectable_decorator(decorator) for decorator in sym_table_node.node.decorators):
             return self._process_injectable_function_signature
 
         return None
+
+    @staticmethod
+    def _is_injectable_decorator(decorator: Expression) -> bool:
+        """Check whether a decorator expression refers to @injectable.
+
+        Both the bare ``@injectable`` form (a ``NameExpr``) and the parametrized
+        ``@injectable(use_cache=False)`` form (a ``CallExpr`` whose callee is the
+        ``injectable`` name) must be recognized -- the parametrized form is the one
+        the README documents and the test suite predominantly uses.
+        """
+        if isinstance(decorator, NameExpr):
+            return _is_injectable_fullname(decorator.fullname)
+        if isinstance(decorator, CallExpr) and isinstance(decorator.callee, NameExpr):
+            return _is_injectable_fullname(decorator.callee.fullname)
+        return False
 
     def get_function_hook(self, fullname: str) -> Callable[[FunctionContext], Type] | None:
         """Hook for modifying method/function calls.
 
         This handles injectable(func) direct calls.
         """
-        if fullname in INJECTABLE_DECORATOR_FULLNAMES:
+        if _is_injectable_fullname(fullname):
             return self._process_injectable_call
         return None
 
@@ -156,11 +177,13 @@ class FastApiInjectablePlugin(Plugin):
             if arg_node.type_annotation and self._is_fastapi_depends_annotation(arg_node.type_annotation):  # type: ignore[arg-type]
                 current_kind = original_arg_kinds[i]
 
-                # Make required arguments optional
-                if current_kind == ARG_POS:  # Required positional
-                    modified_arg_kinds[i] = ARG_OPT  # Make optional positional
-                elif current_kind == ARG_NAMED:  # Required keyword-only
-                    modified_arg_kinds[i] = ARG_NAMED_OPT  # Make optional keyword-only
+                # Make required dependency arguments optional *and keyword-only*. The
+                # runtime always merges injected deps into kwargs (decorator.py), so a
+                # caller may only override a dep by keyword or omit it -- never pass it
+                # positionally. Emitting ARG_OPT (optional positional) would greenlight a
+                # positional call that crashes at runtime, so use ARG_NAMED_OPT instead.
+                if current_kind in (ARG_POS, ARG_NAMED):
+                    modified_arg_kinds[i] = ARG_NAMED_OPT
 
         return modified_arg_kinds
 

--- a/test/test_mypy_plugin.py
+++ b/test/test_mypy_plugin.py
@@ -1,0 +1,141 @@
+"""Tests for the fastapi-injectable mypy plugin.
+
+These drive the real type checker (via ``mypy.api.run``) over small fixture
+modules and assert the plugin's effect on the *caller's* view of an
+``@injectable``-decorated function. The plugin executes inside mypy's own run, so
+it is never exercised by coverage (and is omitted in ``pyproject.toml``); this
+file is the plugin's only safety net.
+
+mypy ships ``mypyc``-compiled wheels that do not target free-threaded builds, so
+it is not installed there -- ``importorskip`` makes those interpreters skip
+cleanly instead of erroring at collection.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+api = pytest.importorskip("mypy.api")
+
+
+_PREAMBLE = (
+    "from typing import Annotated\n"
+    "\n"
+    "from fastapi import Depends\n"
+    "\n"
+    "from fastapi_injectable import injectable\n"
+    "\n"
+    "\n"
+    "class Capital:\n"
+    "    pass\n"
+    "\n"
+    "\n"
+    "class Country:\n"
+    "    pass\n"
+    "\n"
+    "\n"
+    "def get_capital() -> Capital:\n"
+    "    return Capital()\n"
+)
+
+_MYPY_CONFIG = "[mypy]\nplugins = fastapi_injectable.mypy\n"
+
+_VALID_CALLS = 'make_country("Taiwan")\nmake_country("Taiwan", capital=Capital())\n'
+_POSITIONAL_DEPENDENCY_CALL = 'make_country("Taiwan", Capital())  # positional-dependency\n'
+_MISSING_REQUIRED_CALL = "make_country()  # missing-required-arg\n"
+
+
+def _source(decorator: str, calls: str) -> str:
+    """Build a fixture module decorating ``make_country`` with ``decorator``."""
+    return (
+        _PREAMBLE
+        + "\n"
+        + f"@{decorator}\n"
+        + "def make_country(name: str, capital: Annotated[Capital, Depends(get_capital)]) -> Country:\n"
+        + "    return Country()\n"
+        + "\n\n"
+        + calls
+    )
+
+
+def _run_mypy(tmp_path: Path, source: str) -> tuple[int, str]:
+    """Type-check ``source`` with the plugin enabled; return (exit_status, stdout)."""
+    case = tmp_path / "case.py"
+    case.write_text(source)
+    config = tmp_path / "mypy.ini"
+    config.write_text(_MYPY_CONFIG)
+
+    stdout, stderr, status = api.run(
+        [
+            "--config-file",
+            str(config),
+            "--no-incremental",
+            "--cache-dir",
+            str(tmp_path / ".mypy_cache"),
+            "--no-error-summary",
+            "--no-color-output",
+            str(case),
+        ]
+    )
+    assert "Traceback" not in stderr, f"the plugin crashed:\n{stderr}\n{stdout}"
+    return status, stdout
+
+
+def _errors(stdout: str) -> list[tuple[int, str]]:
+    """Parse ``case.py:<line>: error: ...`` lines into (line_number, text) pairs."""
+    parsed: list[tuple[int, str]] = []
+    for line in stdout.splitlines():
+        if ".py:" not in line or ": error:" not in line:
+            continue
+        lineno = int(line.split(".py:", 1)[1].split(":", 1)[0])
+        parsed.append((lineno, line))
+    return parsed
+
+
+def _line_of(source: str, needle: str) -> int:
+    """Return the 1-based line number of the first line containing ``needle``."""
+    return next(lineno for lineno, line in enumerate(source.splitlines(), start=1) if needle in line)
+
+
+def _assert_clean(tmp_path: Path, source: str) -> None:
+    status, stdout = _run_mypy(tmp_path, source)
+    assert status == 0, f"expected a clean type-check, got:\n{stdout}"
+    assert _errors(stdout) == [], f"expected no errors, got:\n{stdout}"
+
+
+def _assert_rejects(tmp_path: Path, source: str, marker: str) -> None:
+    status, stdout = _run_mypy(tmp_path, source)
+    bad_line = _line_of(source, marker)
+    assert status == 1, f"expected a type error at {marker!r}, got status {status}:\n{stdout}"
+    assert any(
+        lineno == bad_line for lineno, _ in _errors(stdout)
+    ), f"expected an error on line {bad_line} ({marker!r}), got:\n{stdout}"
+
+
+def test_bare_injectable_allows_omitting_or_keywording_dependency(tmp_path: Path) -> None:
+    _assert_clean(tmp_path, _source("injectable", _VALID_CALLS))
+
+
+def test_parametrized_injectable_allows_omitting_or_keywording_dependency(tmp_path: Path) -> None:
+    _assert_clean(tmp_path, _source("injectable(use_cache=False)", _VALID_CALLS))
+
+
+def test_bare_injectable_rejects_positional_dependency(tmp_path: Path) -> None:
+    _assert_rejects(tmp_path, _source("injectable", _POSITIONAL_DEPENDENCY_CALL), "# positional-dependency")
+
+
+def test_parametrized_injectable_rejects_positional_dependency(tmp_path: Path) -> None:
+    _assert_rejects(
+        tmp_path,
+        _source("injectable(use_cache=False)", _POSITIONAL_DEPENDENCY_CALL),
+        "# positional-dependency",
+    )
+
+
+def test_injectable_still_requires_non_dependency_arguments(tmp_path: Path) -> None:
+    _assert_rejects(tmp_path, _source("injectable", _MISSING_REQUIRED_CALL), "# missing-required-arg")


### PR DESCRIPTION
# Purpose

The mypy plugin — an advertised headline feature ("Full type-checking support") — had two confirmed bugs on the README-documented path: it silently skipped the parametrized `@injectable(use_cache=False)` form and greenlit positional dependency calls that crash at runtime. This fixes both and adds the plugin's first test suite.

# Changes

### TL;DR

- Parametrized `@injectable(...)` now type-checks like the bare form (was: spurious missing-arg errors)
- Dependency params are now keyword-only-optional, so mypy rejects positional deps that crash at runtime
- Dropped the shipped dev-only `src.` decorator path; match via canonical suffix instead
- New `mypy.api`-based test suite; `tests` nox session now installs mypy
- Verified: ruff, nox mypy-3.10, tests-3.13 (177 passed), coverage 100%

---

The signature hook only matched `NameExpr` decorators, so `@injectable(use_cache=False)` (a `CallExpr`) was skipped — the dominant form in the README and tests; a new `_is_injectable_decorator` helper handles both. Separately, dependency-annotated `ARG_POS` params were converted to `ARG_OPT` (optional *positional*), letting mypy approve `f("a", Cap())` even though the runtime only accepts an injected dep by keyword or omitted — it now emits `ARG_NAMED_OPT`. The hardcoded `src.fastapi_injectable...` fullname is replaced by a canonical-suffix matcher that still recognizes the editable/`src` layout for in-repo checks without leaking the dev path into the installed plugin. Review focus: `_is_injectable_fullname` and the test harness. The plugin runs in mypy's own process so it stays coverage-omitted (unchanged); the new tests are its only safety net. mypy is installed only on non-free-threaded interpreters (no free-threaded wheels) and the test uses `importorskip` to skip cleanly elsewhere.
