### PR TITLE
fix: re-export configure_logging and public exceptions from the package root

### DIFF
--- a/src/fastapi_injectable/__init__.py
+++ b/src/fastapi_injectable/__init__.py
@@ -1,5 +1,6 @@
 from .concurrency import loop_manager, run_coroutine_sync
 from .decorator import injectable
+from .logging import configure_logging
 from .main import register_app, resolve_dependencies
 from .scope import InjectableScope, injectable_scope
 from .util import (

--- a/src/fastapi_injectable/__init__.py
+++ b/src/fastapi_injectable/__init__.py
@@ -1,5 +1,6 @@
 from .concurrency import loop_manager, run_coroutine_sync
 from .decorator import injectable
+from .exception import DependencyCleanupError, RunCoroutineSyncMaxRetriesError
 from .logging import configure_logging
 from .main import register_app, resolve_dependencies
 from .scope import InjectableScope, injectable_scope
@@ -13,7 +14,9 @@ from .util import (
 )
 
 __all__ = [
+    "DependencyCleanupError",
     "InjectableScope",
+    "RunCoroutineSyncMaxRetriesError",
     "async_get_injected_obj",
     "cleanup_all_exit_stacks",
     "cleanup_exit_stack_of_func",

--- a/src/fastapi_injectable/concurrency.py
+++ b/src/fastapi_injectable/concurrency.py
@@ -5,6 +5,8 @@ import threading
 from collections.abc import Awaitable, Coroutine
 from typing import Any, Literal, TypeVar
 
+from .exception import RunCoroutineSyncMaxRetriesError
+
 T = TypeVar("T")
 
 
@@ -103,8 +105,13 @@ class LoopManager:
                 retries += 1
 
         future.cancel()
-        msg = f"Operation timed out after {max_retries} attempts " f"(total {max_retries * timeout} seconds)"
-        raise TimeoutError(msg)
+        msg = (
+            f"run_coroutine_sync timed out under the 'background_thread' loop strategy after "
+            f"{max_retries} attempts (total {max_retries * timeout} seconds). "
+            f"Tune loop_manager._background_loop_result_timeout / "
+            f"loop_manager._background_loop_result_max_retries to raise these limits."
+        )
+        raise RunCoroutineSyncMaxRetriesError(msg)
 
     def in_loop(self) -> bool:
         loop = self.get_loop()

--- a/src/fastapi_injectable/exception.py
+++ b/src/fastapi_injectable/exception.py
@@ -2,5 +2,9 @@ class DependencyCleanupError(Exception):
     """Custom error for dependency cleanup issues."""
 
 
-class RunCoroutineSyncMaxRetriesError(Exception):
-    """Custom error for run coroutine sync max retries issues."""
+class RunCoroutineSyncMaxRetriesError(TimeoutError):
+    """Raised when ``run_coroutine_sync`` exhausts its retries waiting for a result.
+
+    Subclasses the builtin :class:`TimeoutError` so existing ``except TimeoutError``
+    handlers keep working.
+    """

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from src.fastapi_injectable.concurrency import LoopManager, loop_manager, run_coroutine_sync
+from src.fastapi_injectable.exception import RunCoroutineSyncMaxRetriesError
 
 
 @pytest.fixture
@@ -269,7 +270,7 @@ def test_wait_with_retries_success(loop_manager_instance: LoopManager) -> None:
 
 
 def test_wait_with_retries_timeout(loop_manager_instance: LoopManager) -> None:
-    """Test _wait_with_retries with timeout."""
+    """Test _wait_with_retries raises RunCoroutineSyncMaxRetriesError on timeout."""
     mock_future = Mock(spec=concurrent.futures.Future)
     mock_future.result.side_effect = concurrent.futures.TimeoutError()
 
@@ -277,9 +278,12 @@ def test_wait_with_retries_timeout(loop_manager_instance: LoopManager) -> None:
     loop_manager_instance._background_loop_result_max_retries = 2
     loop_manager_instance._background_loop_result_timeout = 0.1
 
-    with pytest.raises(TimeoutError):
+    # RunCoroutineSyncMaxRetriesError subclasses the builtin TimeoutError, so
+    # existing ``except TimeoutError`` handlers keep working (back-compat).
+    with pytest.raises(TimeoutError) as exc_info:
         loop_manager_instance._wait_with_retries(mock_future)
 
+    assert isinstance(exc_info.value, RunCoroutineSyncMaxRetriesError)
     assert mock_future.result.call_count == 2
     mock_future.cancel.assert_called_once()
 

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -1,0 +1,14 @@
+import fastapi_injectable
+
+
+def test_all_public_names_are_importable() -> None:
+    # Every name advertised in __all__ must be resolvable from the package root,
+    # otherwise `from fastapi_injectable import *` raises AttributeError and
+    # documented top-level imports raise ImportError.
+    for name in fastapi_injectable.__all__:
+        assert hasattr(fastapi_injectable, name), name
+
+
+def test_configure_logging_is_exported_from_package_root() -> None:
+    # Exercises the public re-export documented in the README's logging section.
+    assert callable(fastapi_injectable.configure_logging)

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -4,18 +4,19 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from src.fastapi_injectable.logging import configure_logging, logger
+from fastapi_injectable import configure_logging
+from fastapi_injectable.logging import logger
 
 
 @pytest.fixture
 def mock_logger() -> Generator[Mock, None, None]:
-    with patch("src.fastapi_injectable.logging.logger") as mock:
+    with patch("fastapi_injectable.logging.logger") as mock:
         yield mock
 
 
 @pytest.fixture
 def mock_formatter() -> Generator[Mock, None, None]:
-    with patch("src.fastapi_injectable.logging.logging.Formatter") as mock:
+    with patch("fastapi_injectable.logging.logging.Formatter") as mock:
         yield mock
 
 
@@ -69,7 +70,7 @@ def test_configure_logging_handler_already_exists(mock_logger: Mock) -> None:
     mock_logger.handlers = [handler]
 
     # When handlers are compared, they should match
-    with patch("src.fastapi_injectable.logging.logging.StreamHandler") as mock_stream_handler:
+    with patch("fastapi_injectable.logging.logging.StreamHandler") as mock_stream_handler:
         mock_stream_handler.return_value = handler
         configure_logging()
 


### PR DESCRIPTION
## Summary

Fixes the public API surface so the symbols advertised in `__all__` are actually importable from the package root. Two related fixes (one commit each):

### 1. `configure_logging` was in `__all__` but never imported
`configure_logging` was listed in `__init__.py`'s `__all__` but never imported, so the exact snippet documented in the README's logging section failed:

- `from fastapi_injectable import configure_logging` → `ImportError`
- `from fastapi_injectable import *` → `AttributeError`

This was the single most-visible API break. Fix: add `from .logging import configure_logging`.

### 2. Re-export public exceptions + resolve the dead `RunCoroutineSyncMaxRetriesError`
- `DependencyCleanupError` (the primary public exception behind `raise_exception=True`) was only reachable via the `.exception` submodule — inconsistent with every other public symbol and undiscoverable by autocomplete. Now re-exported from the package root.
- `RunCoroutineSyncMaxRetriesError` was defined but **never raised** — `run_coroutine_sync` retry exhaustion surfaced as a bare `TimeoutError`, so `except RunCoroutineSyncMaxRetriesError` caught nothing. It now subclasses `TimeoutError` (back-compat: existing `except TimeoutError` still works) and is raised at the retry-exhaustion site with a message naming the `background_thread` strategy and the tunable timeout / max-retries limits. Both exceptions are now exported from the package root.

## Tests
- **`test/test_init.py` (new)** — asserts every name in `__all__` resolves from the package root (a star-import / re-export regression guard) and that `configure_logging` is callable from the root.
- **`test/test_logging.py`** — repointed imports + patch targets from the `src.fastapi_injectable.logging` submodule to the public `fastapi_injectable` package, so the top-level re-export is now exercised in CI.
- **`test/test_concurrency.py`** — the retry-timeout test now asserts the specific `RunCoroutineSyncMaxRetriesError` type while still proving `TimeoutError` back-compat.

## Not included
README import-line polishing (switching the `.exception` submodule imports to the new top-level imports) is intentionally left out to avoid conflicts with a separate, coordinated README pass.

## Verification (local, via nox)
- `ruff check .` — clean
- `nox -s mypy-3.10` — success (29 files; mypy runs `src test docs/conf.py`)
- `nox -s tests-3.13` — 174 passed
- `coverage` — **100%** (`fail_under = 100`)
