### PR TITLE
feat: add import-time FastAPI compatibility guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,13 @@ print(result) # Output: 'data'
 ### Requirements
 
 - Python `3.10` or higher (including `3.13t`, `3.14t` free-threaded builds)
-- FastAPI `0.112.4` or higher
+- FastAPI `>=0.112.4,<1.0.0`
+
+> `fastapi-injectable` resolves dependencies through FastAPI's internal
+> dependency-resolution API. To keep upgrades safe, it checks that API at import
+> time and raises a clear, version-named `FastAPICompatibilityError` if an
+> incompatible FastAPI is installed — instead of failing later with a cryptic
+> `TypeError`.
 
 <!-- homepage-end -->
 

--- a/src/fastapi_injectable/exception.py
+++ b/src/fastapi_injectable/exception.py
@@ -8,3 +8,14 @@ class RunCoroutineSyncMaxRetriesError(TimeoutError):
     Subclasses the builtin :class:`TimeoutError` so existing ``except TimeoutError``
     handlers keep working.
     """
+
+
+class FastAPICompatibilityError(RuntimeError):
+    """Raised at import time when the installed FastAPI's private dependency API has drifted.
+
+    ``fastapi-injectable`` resolves dependencies through undocumented FastAPI
+    internals (``fastapi.dependencies.utils.get_dependant`` / ``solve_dependencies``).
+    When an allowed-but-incompatible FastAPI release changes that API, this error
+    names the installed version and the supported range instead of letting a raw
+    ``TypeError`` surface deep inside resolution.
+    """

--- a/src/fastapi_injectable/main.py
+++ b/src/fastapi_injectable/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib.metadata
 import inspect
 from collections.abc import Awaitable, Callable
 from contextlib import AsyncExitStack
@@ -10,12 +11,66 @@ from fastapi.dependencies.utils import get_dependant, solve_dependencies
 
 from .async_exit_stack import async_exit_stack_manager
 from .cache import dependency_cache
+from .exception import FastAPICompatibilityError
 from .scope import _current_scope
 
 T = TypeVar("T")
 P = ParamSpec("P")
 _app: FastAPI | None = None
 _app_lock = asyncio.Lock()
+
+# Keep in sync with the ``fastapi`` pin in pyproject.toml.
+_SUPPORTED_FASTAPI_RANGE = ">=0.112.4,<1.0.0"
+# Keyword parameters of FastAPI's private ``solve_dependencies`` that
+# ``resolve_dependencies`` passes by name. If a future FastAPI within the
+# supported range drops one of these, resolution would otherwise fail at call
+# time with a cryptic ``TypeError``; probing at import time turns that into an
+# actionable, version-named error.
+_REQUIRED_SOLVE_DEPENDENCIES_PARAMS = (
+    "dependency_overrides_provider",
+    "dependency_cache",
+    "async_exit_stack",
+    "embed_body_fields",
+)
+
+
+def _verify_fastapi_compatibility(solve: Callable[..., Any]) -> None:
+    """Fail fast if FastAPI's private dependency-resolution API has drifted.
+
+    Introspects ``solve_dependencies`` and raises ``FastAPICompatibilityError``
+    (naming the installed FastAPI version and the supported range) when an
+    expected keyword parameter is missing.
+
+    Args:
+        solve: FastAPI's ``solve_dependencies`` callable (injected for testing).
+    """
+    try:
+        params = inspect.signature(solve).parameters
+    except (ValueError, TypeError):  # pragma: no cover - builtins expose no signature
+        return
+
+    missing = [name for name in _REQUIRED_SOLVE_DEPENDENCIES_PARAMS if name not in params]
+    if not missing:
+        return
+
+    try:
+        installed = importlib.metadata.version("fastapi")
+    except importlib.metadata.PackageNotFoundError:  # pragma: no cover - fastapi is a hard dependency
+        installed = "unknown"
+
+    msg = (
+        f"fastapi-injectable is incompatible with the installed FastAPI version ({installed}). "
+        f"It relies on FastAPI's private dependency-resolution API "
+        f"(fastapi.dependencies.utils.solve_dependencies), whose signature is missing the "
+        f"expected parameter(s): {', '.join(missing)}. "
+        f"Supported FastAPI range: {_SUPPORTED_FASTAPI_RANGE}. "
+        f"Pin FastAPI to a supported version, or report this at "
+        f"https://github.com/JasperSui/fastapi-injectable/issues."
+    )
+    raise FastAPICompatibilityError(msg)
+
+
+_verify_fastapi_compatibility(solve_dependencies)
 
 
 async def register_app(app: FastAPI) -> None:

--- a/test/test_compat_guard.py
+++ b/test/test_compat_guard.py
@@ -1,0 +1,59 @@
+import importlib.metadata
+
+import pytest
+from fastapi.dependencies.utils import solve_dependencies
+
+from src.fastapi_injectable.exception import FastAPICompatibilityError
+from src.fastapi_injectable.main import _verify_fastapi_compatibility
+
+
+def test_verify_fastapi_compatibility_passes_for_installed_fastapi() -> None:
+    # The installed FastAPI is within the supported range, so the probe is a no-op.
+    _verify_fastapi_compatibility(solve_dependencies)
+
+
+def test_verify_fastapi_compatibility_passes_when_all_params_present() -> None:
+    def fake_solve(
+        *,
+        dependency_overrides_provider: object = None,
+        dependency_cache: object = None,
+        async_exit_stack: object = None,
+        embed_body_fields: bool = False,
+    ) -> None:
+        """A stub exposing every keyword param we rely on."""
+
+    _verify_fastapi_compatibility(fake_solve)
+
+
+def test_verify_fastapi_compatibility_reports_only_missing_params() -> None:
+    def fake_solve(
+        *,
+        dependency_overrides_provider: object = None,
+        dependency_cache: object = None,
+        async_exit_stack: object = None,
+    ) -> None:
+        """A stub missing only ``embed_body_fields``."""
+
+    with pytest.raises(FastAPICompatibilityError) as exc_info:
+        _verify_fastapi_compatibility(fake_solve)
+
+    message = str(exc_info.value)
+    assert "embed_body_fields" in message
+    assert "async_exit_stack" not in message.split("expected parameter(s):")[1].split(".")[0]
+
+
+def test_verify_fastapi_compatibility_raises_when_param_missing() -> None:
+    def fake_solve(request: object, dependant: object) -> None:
+        """A solve_dependencies stub missing every keyword param we rely on."""
+
+    with pytest.raises(FastAPICompatibilityError) as exc_info:
+        _verify_fastapi_compatibility(fake_solve)
+
+    message = str(exc_info.value)
+    # Names the missing parameter(s) so the failure is actionable.
+    assert "embed_body_fields" in message
+    assert "async_exit_stack" in message
+    assert "dependency_overrides_provider" in message
+    # Names the installed FastAPI version and the supported range.
+    assert importlib.metadata.version("fastapi") in message
+    assert ">=0.112.4,<1.0.0" in message


### PR DESCRIPTION
# Purpose
`fastapi-injectable` resolves dependencies through FastAPI's undocumented internals (`get_dependant` / `solve_dependencies`), which have already shifted twice within the supported `>=0.112.4,<1.0.0` range. Without a guard, an allowed-but-incompatible FastAPI upgrade fails deep in resolution with a cryptic `TypeError`. This fails fast at import time with a clear, version-named error instead.

# Changes

### TL;DR
- Import-time `inspect.signature(solve_dependencies)` probe in `main.py`
- New `FastAPICompatibilityError`, naming the installed FastAPI version + supported range
- Turns a cryptic call-time `TypeError` into an actionable message
- Version pin unchanged; README Requirements note added
- Tests added; 100% coverage maintained

---

The probe checks that `solve_dependencies` still accepts the keyword params `resolve_dependencies` passes it (`dependency_overrides_provider`, `dependency_cache`, `async_exit_stack`, `embed_body_fields`). On a missing param it raises `FastAPICompatibilityError` with the installed version (via `importlib.metadata`) and the supported range. The guard runs once at module import, so it adds no per-call overhead. Verified locally via nox: `mypy-3.10`, `ruff`, `tests-3.13` (176 passed), `coverage` (100%).
