### PR TITLE
feat: ship pytest plugin for test isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,45 @@ This is particularly useful when:
 - You're using third-party libraries that call your code internally
 - You want to maintain a single source of truth for long-running services
 
+### Test Isolation
+
+`fastapi-injectable` keeps its dependency cache and exit stacks in **process-global** singletons, so a value cached — or a generator left open — by one test can leak into the next. To make "tests are isolated" the default, the package ships a pytest plugin that resets both around every test.
+
+The plugin is registered automatically when you install `fastapi-injectable` (via a `pytest11` entry point) — there's nothing to import or enable. By default it resets the global dependency cache and exit stacks around **every** test, so leakage simply can't happen:
+
+```python
+from fastapi_injectable import get_injected_obj
+
+def test_a() -> None:
+    service = get_injected_obj(get_service)  # populates the process-global cache
+    ...
+
+def test_b() -> None:
+    # Starts from a clean slate — nothing from test_a leaks in.
+    service = get_injected_obj(get_service)
+```
+
+Prefer to manage isolation yourself? Turn the autouse behaviour off in your pytest config and request the `injectable_cleanup` fixture only where you need it:
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+injectable_autouse_cleanup = false
+```
+
+```python
+import pytest
+
+# Reset around a single test:
+def test_one(injectable_cleanup: None) -> None:
+    ...
+
+# ...or for a whole module:
+pytestmark = pytest.mark.usefixtures("injectable_cleanup")
+```
+
+Both the autouse reset and the `injectable_cleanup` fixture work in sync and async tests alike, and honour whatever loop strategy you've configured via `loop_manager`.
+
 <!-- usage-end -->
 
 ## Advanced Scenarios

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+"""Root pytest configuration for fastapi-injectable's own test suite.
+
+The shipped pytest plugin loads automatically via its ``pytest11`` entry point (the
+same way adopters get it), so the suite dogfoods its own test-isolation behaviour.
+Here we only enable ``pytester`` for the plugin's end-to-end tests.
+"""
+
+pytest_plugins = ["pytester"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ Repository = "https://github.com/JasperSui/fastapi-injectable"
 Documentation = "https://fastapi-injectable.readthedocs.io"
 Changelog = "https://github.com/JasperSui/fastapi-injectable/releases"
 
+[project.entry-points.pytest11]
+fastapi_injectable = "fastapi_injectable.pytest_plugin"
+
 [dependency-groups]
 dev = [
     "nox>=2025.05.01",

--- a/src/fastapi_injectable/pytest_plugin.py
+++ b/src/fastapi_injectable/pytest_plugin.py
@@ -1,0 +1,77 @@
+"""Pytest plugin that keeps fastapi-injectable's process-global state isolated between tests.
+
+fastapi-injectable keeps process-global singletons -- the dependency cache
+(:data:`fastapi_injectable.cache.dependency_cache`) and the exit-stack manager
+(:data:`fastapi_injectable.async_exit_stack.async_exit_stack_manager`). Because they
+outlive any single test, a value cached -- or a generator left open -- by one test can
+leak into the next. This plugin resets both so that "tests are isolated" is the default.
+
+Installing fastapi-injectable registers this plugin automatically (via the ``pytest11``
+entry point). The reset runs as an autouse fixture, enabled by default; disable it with::
+
+    [tool.pytest.ini_options]
+    injectable_autouse_cleanup = false
+
+and request the :func:`injectable_cleanup` fixture explicitly where you still want it.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+
+from .concurrency import run_coroutine_sync
+from .util import cleanup_all_exit_stacks, clear_dependency_cache
+
+_AUTOUSE_INI = "injectable_autouse_cleanup"
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the ``injectable_autouse_cleanup`` ini option (enabled by default)."""
+    parser.addini(
+        _AUTOUSE_INI,
+        help=(
+            "Reset fastapi-injectable's global dependency cache and exit stacks around "
+            "every test (default: true). Set to false to manage isolation yourself with "
+            "the `injectable_cleanup` fixture."
+        ),
+        type="bool",
+        default=True,
+    )
+
+
+async def _areset_injectable_state() -> None:
+    await cleanup_all_exit_stacks()
+    await clear_dependency_cache()
+
+
+def reset_injectable_state() -> None:
+    """Reset fastapi-injectable's process-global cache and exit stacks.
+
+    Wrapped with :func:`run_coroutine_sync` so it works from sync and async tests alike,
+    and so it honours whatever loop strategy ``loop_manager`` is configured with.
+    """
+    run_coroutine_sync(_areset_injectable_state())
+
+
+def _cleanup_around_test(*, enabled: bool) -> Iterator[None]:
+    if enabled:
+        reset_injectable_state()
+    yield
+    if enabled:
+        reset_injectable_state()
+
+
+@pytest.fixture
+def injectable_cleanup() -> Iterator[None]:
+    """Reset fastapi-injectable's global cache + exit stacks around the test.
+
+    Request this explicitly (e.g. ``pytestmark = pytest.mark.usefixtures("injectable_cleanup")``)
+    to isolate a test or module when you have turned the autouse behaviour off.
+    """
+    yield from _cleanup_around_test(enabled=True)
+
+
+@pytest.fixture(autouse=True)
+def _injectable_autouse_cleanup(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Autouse counterpart of :func:`injectable_cleanup`, gated by the ini option."""
+    yield from _cleanup_around_test(enabled=request.config.getini(_AUTOUSE_INI))

--- a/test/test_pytest_plugin.py
+++ b/test/test_pytest_plugin.py
@@ -1,0 +1,89 @@
+from contextlib import AsyncExitStack
+from unittest.mock import Mock
+
+import pytest
+
+from src.fastapi_injectable import pytest_plugin
+from src.fastapi_injectable.async_exit_stack import async_exit_stack_manager
+from src.fastapi_injectable.cache import dependency_cache
+
+
+def test_reset_injectable_state_clears_cache_and_stacks() -> None:
+    def marker() -> None:
+        """A stand-in provider key for the exit-stack manager."""
+
+    dependency_cache.get()[("leaked",)] = object()
+    async_exit_stack_manager._stacks[marker] = AsyncExitStack()
+    assert dependency_cache.get()
+    assert async_exit_stack_manager._stacks
+
+    pytest_plugin.reset_injectable_state()
+
+    assert dependency_cache.get() == {}
+    assert dict(async_exit_stack_manager._stacks) == {}
+
+
+def test_addoption_registers_autouse_ini() -> None:
+    parser = Mock()
+
+    pytest_plugin.pytest_addoption(parser)
+
+    parser.addini.assert_called_once()
+    (name,), kwargs = parser.addini.call_args
+    assert name == "injectable_autouse_cleanup"
+    assert kwargs["type"] == "bool"
+    assert kwargs["default"] is True
+
+
+def test_cleanup_around_test_resets_when_enabled() -> None:
+    dependency_cache.get()[("before",)] = object()
+
+    gen = pytest_plugin._cleanup_around_test(enabled=True)
+    next(gen)  # runs the "before" reset
+    assert dependency_cache.get() == {}
+
+    dependency_cache.get()[("during",)] = object()
+    with pytest.raises(StopIteration):
+        next(gen)  # runs the "after" reset
+    assert dependency_cache.get() == {}
+
+
+def test_cleanup_around_test_noop_when_disabled() -> None:
+    sentinel = object()
+    dependency_cache.get()[("kept",)] = sentinel
+
+    gen = pytest_plugin._cleanup_around_test(enabled=False)
+    next(gen)
+    # Disabled: state is left untouched both before and after the yield.
+    assert dependency_cache.get().get(("kept",)) is sentinel
+    with pytest.raises(StopIteration):
+        next(gen)
+    assert dependency_cache.get().get(("kept",)) is sentinel
+
+    dependency_cache.get().clear()
+
+
+def test_injectable_cleanup_fixture_provides_clean_state(injectable_cleanup: None) -> None:
+    # Requesting the shipped fixture runs its "before" reset, so the test starts clean.
+    assert dependency_cache.get() == {}
+
+
+def test_plugin_prevents_cross_test_leakage(pytester: pytest.Pytester) -> None:
+    # The plugin auto-loads in the subprocess via its pytest11 entry point.
+    pytester.makepyfile(
+        """
+        from fastapi_injectable.cache import dependency_cache
+
+        def test_a_populates_cache() -> None:
+            dependency_cache.get()[("leaked",)] = object()
+            assert dependency_cache.get()
+
+        def test_b_starts_clean() -> None:
+            # The autouse cleanup wiped test_a's leftover global state.
+            assert dependency_cache.get() == {}
+        """
+    )
+
+    result = pytester.runpytest_subprocess()
+
+    result.assert_outcomes(passed=2)


### PR DESCRIPTION
# Purpose
`fastapi-injectable`'s dependency cache and exit stacks are process-global singletons, so a value cached — or a generator left open — by one test leaks into the next, and every adopter re-derives the same autouse cleanup fixture. This ships a pytest plugin that makes "tests are isolated" the default.

# Changes

### TL;DR
- New `pytest_plugin.py`, auto-registered via `[project.entry-points.pytest11]`
- Autouse-by-default reset of the global cache + exit stacks around every test
- Opt out with `injectable_autouse_cleanup = false`; explicit `injectable_cleanup` fixture for manual control
- Works in sync and async tests; honours the configured `loop_manager` strategy
- Repo dogfoods it (root `conftest.py`); 100% coverage incl. a `pytester` leakage-prevention proof

---

The reset awaits `cleanup_all_exit_stacks()` + `clear_dependency_cache()` via `run_coroutine_sync`, so a single fixture covers sync and async tests. Autouse is **on by default** (deliberate choice — isolation-by-default); the opt-out ini flag exists because the function-scoped reset also wipes any session/module-scoped injectable state between tests. The repo's own suite loads the plugin via its entry point and a root `conftest.py` (which also enables `pytester`). Verified locally via nox: `mypy-3.10`, `ruff`, `ruff format --check`, `tests-3.13` (178 passed), `coverage` (100%).
