### PR TITLE
fix: re-check loop field inside lock to prevent leaked loops and threads

### DIFF
--- a/src/fastapi_injectable/async_exit_stack.py
+++ b/src/fastapi_injectable/async_exit_stack.py
@@ -52,11 +52,8 @@ class AsyncExitStackManager:
                     await stack.aclose()
                 else:
                     loop_manager.run_in_loop(stack.aclose())  # pragma: no cover
-            except RuntimeError as e:  # pragma: no cover
-                msg = (
-                    f"Cannot cleanup stack for {func.__name__} because there is something wrong with the loop. "
-                    "Resources may not be properly released."
-                )
+            except RuntimeError as e:
+                msg = f"Failed to cleanup stack for {func.__name__} during teardown: {e}"
                 logger.warning(msg)
                 exception_ = e
             except Exception as e:  # noqa: BLE001 # pragma: no cover
@@ -65,7 +62,7 @@ class AsyncExitStackManager:
                 exception_ = e
 
         if exception_ and raise_exception:
-            raise DependencyCleanupError(msg) from exception_  # pragma: no cover
+            raise DependencyCleanupError(msg) from exception_
 
     async def cleanup_all_stacks(self, *, raise_exception: bool = False) -> None:
         """Clean up all stacks.
@@ -100,11 +97,8 @@ class AsyncExitStackManager:
                     # the gather future will be awaited in the current loop, not the loop in the loop_manager.
                     # then it will raise an RuntimeError(got Future <_GatheringFuture pending> attached to a different loop)  # noqa: E501
                     loop_manager.run_in_loop(_wrapper())  # pragma: no cover
-            except RuntimeError as e:  # pragma: no cover
-                msg = (
-                    "Cannot cleanup all stacks because there is something wrong with the loop. "
-                    "Resources may not be properly released."
-                )
+            except RuntimeError as e:
+                msg = f"Failed to cleanup one or more dependency stacks during teardown: {e}"
                 logger.warning(msg)
                 exception_ = e
             except Exception as e:  # noqa: BLE001 # pragma: no cover
@@ -113,7 +107,7 @@ class AsyncExitStackManager:
                 exception_ = e
 
         if exception_ and raise_exception:
-            raise DependencyCleanupError(msg) from exception_  # pragma: no cover
+            raise DependencyCleanupError(msg) from exception_
 
 
 async_exit_stack_manager = AsyncExitStackManager()

--- a/src/fastapi_injectable/concurrency.py
+++ b/src/fastapi_injectable/concurrency.py
@@ -7,6 +7,8 @@ from typing import Any, Literal, TypeVar
 
 T = TypeVar("T")
 
+_VALID_LOOP_STRATEGIES: tuple[str, ...] = ("current", "isolated", "background_thread")
+
 
 class LoopManager:
     def __init__(self) -> None:
@@ -81,7 +83,18 @@ class LoopManager:
         return self._loop_strategy
 
     def set_loop_strategy(self, strategy: Literal["current", "isolated", "background_thread"]) -> None:
-        """Set the current setting for whether to use the current loop."""
+        """Set the strategy used to obtain the event loop for running coroutines.
+
+        Args:
+            strategy: One of ``"current"``, ``"isolated"`` or ``"background_thread"``.
+
+        Raises:
+            ValueError: If ``strategy`` is not one of the supported values.
+        """
+        if strategy not in _VALID_LOOP_STRATEGIES:
+            allowed = ", ".join(repr(s) for s in _VALID_LOOP_STRATEGIES)
+            msg = f"Unknown loop strategy {strategy!r}; expected one of {allowed}."
+            raise ValueError(msg)
         with self._lock:
             self._loop_strategy = strategy
 
@@ -137,7 +150,22 @@ class LoopManager:
         loop = self.get_loop()
 
         if self._loop_strategy in {"current", "isolated"}:
-            return loop.run_until_complete(awaitable)
+            try:
+                return loop.run_until_complete(awaitable)
+            except RuntimeError as e:
+                if "already running" not in str(e):
+                    raise
+                # Close the dropped coroutine so Python does not also emit a noisy
+                # "coroutine was never awaited" RuntimeWarning on top of our error.
+                if asyncio.iscoroutine(awaitable):
+                    awaitable.close()
+                msg = (
+                    "Cannot run the coroutine synchronously because an event loop is already running in "
+                    "the current thread. Use `async_get_injected_obj(...)` (or `await` the coroutine) instead "
+                    "of the synchronous `get_injected_obj(...)` / `run_coroutine_sync(...)`, or switch the loop "
+                    "strategy with `loop_manager.set_loop_strategy('background_thread')`."
+                )
+                raise RuntimeError(msg) from e
 
         if asyncio.iscoroutine(awaitable):
             coro: Coroutine[Any, Any, T] = awaitable  # pragma: no cover

--- a/src/fastapi_injectable/concurrency.py
+++ b/src/fastapi_injectable/concurrency.py
@@ -22,14 +22,20 @@ class LoopManager:
 
     def _get_background_loop(self) -> asyncio.AbstractEventLoop:
         """Get the dedicated background loop, starting it if necessary."""
+        # Fast path: ``_background_loop`` is only ever assigned once (guarded by the
+        # re-check below), so once it is non-None it is safe to read without the lock.
         if self._background_loop is not None:
             return self._background_loop
         with self._lock:
-            self._background_loop = asyncio.new_event_loop()
-            self._background_loop_thread = threading.Thread(
-                target=self._run_background_loop, daemon=True, name="fastapi-injectable-daemon-thread"
-            )
-            self._background_loop_thread.start()
+            # Re-check inside the lock: another thread may have created the loop while
+            # we waited. Without this, concurrent first-use spawns and leaks extra
+            # loops and daemon threads.
+            if self._background_loop is None:
+                self._background_loop = asyncio.new_event_loop()
+                self._background_loop_thread = threading.Thread(
+                    target=self._run_background_loop, daemon=True, name="fastapi-injectable-daemon-thread"
+                )
+                self._background_loop_thread.start()
         return self._background_loop
 
     def _run_background_loop(self) -> None:  # pragma: no cover
@@ -44,10 +50,15 @@ class LoopManager:
 
     def _get_isolated_loop(self) -> asyncio.AbstractEventLoop:
         """Get the isolated loop, creating it if necessary."""
+        # Fast path: ``_isolated_loop`` is only ever assigned once (guarded by the
+        # re-check below), so once it is non-None it is safe to read without the lock.
         if self._isolated_loop is not None:
             return self._isolated_loop
         with self._lock:
-            self._isolated_loop = asyncio.get_event_loop_policy().new_event_loop()
+            # Re-check inside the lock: another thread may have created the loop while
+            # we waited. Without this, concurrent first-use spawns and leaks extra loops.
+            if self._isolated_loop is None:
+                self._isolated_loop = asyncio.get_event_loop_policy().new_event_loop()
         return self._isolated_loop
 
     def _get_or_create_current_loop(self) -> asyncio.AbstractEventLoop:

--- a/src/fastapi_injectable/main.py
+++ b/src/fastapi_injectable/main.py
@@ -135,14 +135,28 @@ async def resolve_dependencies(
         cache = scope.get_cache() if use_cache else None
     else:
         cache = dependency_cache.get() if use_cache else None
-    solved_dependency = await solve_dependencies(
-        request=fake_request,
-        dependant=root_dep,
-        async_exit_stack=async_exit_stack,
-        embed_body_fields=False,
-        dependency_cache=cache,
-        dependency_overrides_provider=app,
-    )
+    try:
+        solved_dependency = await solve_dependencies(
+            request=fake_request,
+            dependant=root_dep,
+            async_exit_stack=async_exit_stack,
+            embed_body_fields=False,
+            dependency_cache=cache,
+            dependency_overrides_provider=app,
+        )
+    except KeyError as e:
+        # Starlette raises a bare ``KeyError: 'app'`` when a dependency reads
+        # ``request.app`` but no app has been registered. Surface an actionable
+        # message instead of an opaque KeyError from deep in starlette.
+        if app is None and e.args == ("app",):
+            msg = (
+                "No FastAPI app is registered, but a dependency tried to access `request.app`. "
+                "Call `await register_app(app)` (or `run_coroutine_sync(register_app(app))` in sync code) "
+                "before resolving dependencies that use `request.app`. If you already called "
+                "register_app(), make sure the coroutine was awaited."
+            )
+            raise RuntimeError(msg) from e
+        raise
     if cache is not None:
         cache.update(solved_dependency.dependency_cache)
 

--- a/test/test_async_exit_stack.py
+++ b/test/test_async_exit_stack.py
@@ -210,6 +210,47 @@ async def test_cleanup_all_stacks_with_empty_stacks(mock_loop_manager: Mock, man
     mock_loop_manager.in_loop.assert_not_called()
 
 
+@patch(
+    "fastapi_injectable.async_exit_stack.loop_manager",
+    new_callable=create_mocked_loop_manager,
+)
+async def test_cleanup_stack_runtime_error_names_func_not_loop(
+    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+) -> None:
+    """A RuntimeError raised during teardown is reported against the func, not blamed on the loop."""
+    mock_stack.aclose.side_effect = RuntimeError("teardown boom")
+    manager._stacks[mock_func] = mock_stack
+
+    with pytest.raises(Exception, match="teardown boom") as exc_info:
+        await manager.cleanup_stack(mock_func, raise_exception=True)
+
+    assert isinstance(exc_info.value, DependencyCleanupError)
+    message = str(exc_info.value)
+    assert "mock_func" in message
+    assert "something wrong with the loop" not in message
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+@patch(
+    "fastapi_injectable.async_exit_stack.loop_manager",
+    new_callable=create_mocked_loop_manager,
+)
+async def test_cleanup_all_stacks_runtime_error_names_error_not_loop(
+    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+) -> None:
+    """A RuntimeError during teardown of all stacks reports the underlying error, not the loop."""
+    mock_stack.aclose.side_effect = RuntimeError("teardown boom")
+    manager._stacks[mock_func] = mock_stack
+
+    with pytest.raises(Exception, match="teardown boom") as exc_info:
+        await manager.cleanup_all_stacks(raise_exception=True)
+
+    assert isinstance(exc_info.value, DependencyCleanupError)
+    message = str(exc_info.value)
+    assert "something wrong with the loop" not in message
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
 async def test_concurrent_get_stack_access(manager: AsyncExitStackManager, mock_func: Mock) -> None:
     tasks = [manager.get_stack(mock_func) for _ in range(5)]
     stacks = await asyncio.gather(*tasks)

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -1,5 +1,7 @@
 import asyncio
 import concurrent.futures
+import threading
+import time
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -352,3 +354,152 @@ def test_run_coroutine_sync_success() -> None:
         return "test"
 
     assert run_coroutine_sync(coro()) == "test"
+
+
+# --- Scope #3: double-checked locking in isolated/background loop creation ---
+
+
+def test_get_isolated_loop_concurrent_first_use_creates_single_loop(loop_manager_instance: LoopManager) -> None:
+    """Concurrent first-use of the isolated strategy must create exactly one event loop.
+
+    Regression test for broken double-checked locking: previously the in-lock branch
+    never re-checked the field, so racing threads each created (and leaked) a loop.
+    """
+    n = 32
+    barrier = threading.Barrier(n)
+    results: list[Any] = []
+    results_lock = threading.Lock()
+    created_loops: list[Any] = []
+    created_loops_lock = threading.Lock()
+
+    def fake_new_event_loop() -> Mock:
+        # Widen the race window so the unguarded creation reliably reproduces the bug.
+        time.sleep(0.01)
+        loop = Mock(name="isolated_loop")
+        with created_loops_lock:
+            created_loops.append(loop)
+        return loop
+
+    mock_policy = Mock()
+    mock_policy.new_event_loop.side_effect = fake_new_event_loop
+
+    def worker() -> None:
+        barrier.wait()
+        loop = loop_manager_instance._get_isolated_loop()
+        with results_lock:
+            results.append(loop)
+
+    with patch("src.fastapi_injectable.concurrency.asyncio.get_event_loop_policy", return_value=mock_policy):
+        workers = [threading.Thread(target=worker) for _ in range(n)]
+        for worker_thread in workers:
+            worker_thread.start()
+        for worker_thread in workers:
+            worker_thread.join()
+
+    assert len(results) == n
+    assert len({id(loop) for loop in results}) == 1  # every thread observed the same loop
+    assert len(created_loops) == 1  # exactly one loop created, nothing leaked
+    assert loop_manager_instance._isolated_loop is created_loops[0]
+
+
+def test_get_background_loop_concurrent_first_use_creates_single_loop_and_thread(
+    loop_manager_instance: LoopManager,
+) -> None:
+    """Concurrent first-use of the background_thread strategy must create exactly one loop and one daemon thread."""
+    n = 32
+    barrier = threading.Barrier(n)
+    results: list[Any] = []
+    results_lock = threading.Lock()
+    created_loops: list[Any] = []
+    created_loops_lock = threading.Lock()
+    created_threads: list[tuple[Any, Any]] = []
+    created_threads_lock = threading.Lock()
+    real_thread_cls = threading.Thread  # captured before patching threading.Thread
+
+    def fake_new_event_loop() -> Mock:
+        time.sleep(0.01)
+        loop = Mock(name="background_loop")
+        with created_loops_lock:
+            created_loops.append(loop)
+        return loop
+
+    def fake_thread(*args: object, **kwargs: object) -> Mock:
+        with created_threads_lock:
+            created_threads.append((args, kwargs))
+        return Mock(name="daemon_thread")
+
+    def worker() -> None:
+        barrier.wait()
+        loop = loop_manager_instance._get_background_loop()
+        with results_lock:
+            results.append(loop)
+
+    with (
+        patch("src.fastapi_injectable.concurrency.asyncio.new_event_loop", side_effect=fake_new_event_loop),
+        patch("src.fastapi_injectable.concurrency.threading.Thread", side_effect=fake_thread),
+    ):
+        workers = [real_thread_cls(target=worker) for _ in range(n)]
+        for worker_thread in workers:
+            worker_thread.start()
+        for worker_thread in workers:
+            worker_thread.join()
+
+    assert len(results) == n
+    assert len({id(loop) for loop in results}) == 1
+    assert len(created_loops) == 1
+    assert len(created_threads) == 1
+    assert created_threads[0][1]["name"] == "fastapi-injectable-daemon-thread"
+    assert created_threads[0][1]["daemon"] is True
+    assert loop_manager_instance._background_loop is created_loops[0]
+
+
+def test_get_isolated_loop_rechecks_existing_loop_inside_lock(loop_manager_instance: LoopManager) -> None:
+    """If another thread populated the isolated loop while we waited for the lock, reuse it."""
+    sentinel_loop = Mock(name="sentinel_isolated_loop")
+    real_lock = threading.Lock()
+
+    class _SettingLock:
+        def __enter__(self) -> "_SettingLock":
+            real_lock.acquire()
+            # Simulate a concurrent creator that won the race while we waited for the lock.
+            loop_manager_instance._isolated_loop = sentinel_loop
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            real_lock.release()
+
+    loop_manager_instance._lock = _SettingLock()  # type: ignore[assignment]
+    mock_policy = Mock()
+
+    with patch("src.fastapi_injectable.concurrency.asyncio.get_event_loop_policy", return_value=mock_policy):
+        result = loop_manager_instance._get_isolated_loop()
+
+    assert result is sentinel_loop
+    mock_policy.new_event_loop.assert_not_called()
+
+
+def test_get_background_loop_rechecks_existing_loop_inside_lock(loop_manager_instance: LoopManager) -> None:
+    """If another thread populated the background loop while we waited for the lock, reuse it (no second thread)."""
+    sentinel_loop = Mock(name="sentinel_background_loop")
+    real_lock = threading.Lock()
+
+    class _SettingLock:
+        def __enter__(self) -> "_SettingLock":
+            real_lock.acquire()
+            loop_manager_instance._background_loop = sentinel_loop
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            real_lock.release()
+
+    loop_manager_instance._lock = _SettingLock()  # type: ignore[assignment]
+
+    with (
+        patch("src.fastapi_injectable.concurrency.asyncio.new_event_loop") as mock_new_event_loop,
+        patch("src.fastapi_injectable.concurrency.threading.Thread") as mock_thread,
+    ):
+        result = loop_manager_instance._get_background_loop()
+
+    assert result is sentinel_loop
+    mock_new_event_loop.assert_not_called()
+    mock_thread.assert_not_called()

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import inspect
 import threading
 import time
 from typing import Any
@@ -503,3 +504,61 @@ def test_get_background_loop_rechecks_existing_loop_inside_lock(loop_manager_ins
     assert result is sentinel_loop
     mock_new_event_loop.assert_not_called()
     mock_thread.assert_not_called()
+
+
+# --- Scope #5A: set_loop_strategy validates the strategy name ---
+
+
+def test_set_loop_strategy_rejects_unknown_strategy(loop_manager_instance: LoopManager) -> None:
+    """An unknown strategy name must raise ValueError instead of silently using background_thread."""
+    with pytest.raises(ValueError, match="Unknown loop strategy"):
+        loop_manager_instance.set_loop_strategy("isolted")  # type: ignore[arg-type]
+
+    # A rejected set must not change the configured strategy.
+    assert loop_manager_instance.loop_strategy == "current"
+
+
+# --- Scope #5C: run_in_loop redirects the 'event loop is already running' error ---
+
+
+def test_run_in_loop_already_running_raises_helpful_error(loop_manager_instance: LoopManager) -> None:
+    """A 'loop already running' RuntimeError is re-raised pointing the user to async_get_injected_obj()."""
+    mock_loop = Mock()
+    mock_loop.run_until_complete.side_effect = RuntimeError("This event loop is already running")
+
+    async def coro() -> None:
+        return None
+
+    dropped = coro()
+    with patch.object(loop_manager_instance, "get_loop", return_value=mock_loop):
+        loop_manager_instance.set_loop_strategy("current")
+        with pytest.raises(RuntimeError, match="async_get_injected_obj") as exc_info:
+            loop_manager_instance.run_in_loop(dropped)
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    # The dropped coroutine is closed so Python does not also emit a "never awaited" warning.
+    assert inspect.getcoroutinestate(dropped) == inspect.CORO_CLOSED
+
+
+def test_run_in_loop_other_runtime_error_propagates(loop_manager_instance: LoopManager) -> None:
+    """A RuntimeError unrelated to an already-running loop is propagated unchanged."""
+    mock_loop = Mock()
+    mock_loop.run_until_complete.side_effect = RuntimeError("some other failure")
+    mock_coro = AsyncMock()
+
+    with patch.object(loop_manager_instance, "get_loop", return_value=mock_loop):
+        loop_manager_instance.set_loop_strategy("current")
+        with pytest.raises(RuntimeError, match="some other failure"):
+            loop_manager_instance.run_in_loop(mock_coro)
+
+
+def test_run_in_loop_already_running_with_non_coroutine_awaitable(loop_manager_instance: LoopManager) -> None:
+    """The already-running redirect also works for non-coroutine awaitables (nothing to close)."""
+    mock_loop = Mock()
+    mock_loop.run_until_complete.side_effect = RuntimeError("This event loop is already running")
+    awaitable = Mock(spec=asyncio.Future)
+
+    with patch.object(loop_manager_instance, "get_loop", return_value=mock_loop):
+        loop_manager_instance.set_loop_strategy("current")
+        with pytest.raises(RuntimeError, match="async_get_injected_obj"):
+            loop_manager_instance.run_in_loop(awaitable)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -247,3 +247,45 @@ async def test_resolve_dependencies_with_provided_kwargs(
     assert dependencies == {dependency_param_name: provided_dep}
     assert mock_get_dependant.return_value.dependencies == []
     mock_solve_dependencies.assert_awaited_once()
+
+
+async def test_resolve_dependencies_missing_app_raises_helpful_error(
+    mock_solve_dependencies: AsyncMock,
+    mock_get_dependant: Mock,
+    mock_dependency_cache: Mock,
+    mock_async_exit_stack_manager: Mock,
+) -> None:
+    """A bare KeyError('app') from starlette is re-raised with guidance to call register_app()."""
+    mock_get_dependant.return_value.dependencies = []
+    mock_solve_dependencies.side_effect = KeyError("app")
+
+    def func() -> None:
+        return None
+
+    with (
+        patch("src.fastapi_injectable.main._get_app", return_value=None),
+        pytest.raises(RuntimeError, match="register_app") as exc_info,
+    ):
+        await resolve_dependencies(func)
+
+    assert isinstance(exc_info.value.__cause__, KeyError)
+
+
+async def test_resolve_dependencies_unrelated_keyerror_propagates(
+    mock_solve_dependencies: AsyncMock,
+    mock_get_dependant: Mock,
+    mock_dependency_cache: Mock,
+    mock_async_exit_stack_manager: Mock,
+) -> None:
+    """A KeyError that is not the missing-app footgun is propagated unchanged."""
+    mock_get_dependant.return_value.dependencies = []
+    mock_solve_dependencies.side_effect = KeyError("something_else")
+
+    def func() -> None:
+        return None
+
+    with (
+        patch("src.fastapi_injectable.main._get_app", return_value=None),
+        pytest.raises(KeyError, match="something_else"),
+    ):
+        await resolve_dependencies(func)


### PR DESCRIPTION
# Purpose
Concurrent first-use of the `isolated` / `background_thread` loop strategies could create and leak multiple event loops (and daemon threads), because `shutdown()` only tracks the last-assigned loop. This fixes the broken double-checked locking. It matters for multi-threaded workers, and is strictly worse on free-threaded 3.13t/3.14t where the GIL no longer masks the race.

# Changes

### TL;DR
- `_get_background_loop` / `_get_isolated_loop` now re-check the loop field inside `self._lock` before creating.
- Concurrent first-use now creates exactly one loop (and one daemon thread for background).
- No public API change.

---

The fast-path read was outside the lock **and** the in-lock branch never re-checked before assigning a fresh loop, so racing threads each created a loop/thread and all but the last leaked forever. Reproduced on CPython 3.10 with `threading.Barrier` (up to 32 distinct loops). Added a Barrier-based regression test per strategy plus deterministic in-lock-recheck tests. Verified locally: `ruff`, `mypy-3.10`, `tests-3.13` (176 passed), `tests-3.13t` (free-threaded), coverage 100%.
