### PR TITLE
bump: from 1.5.0 to 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi-injectable"
-version = "1.5.0"
+version = "1.6.0"
 description = "Use FastAPI's Depends() anywhere — in CLI tools, Celery tasks, background workers, and more. No refactoring needed."
 authors = [{ name = "Jasper Sui", email = "suiyang03@gmail.com" }]
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-injectable"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Version bump from **1.5.0** to **1.6.0**.

This release ships a pytest plugin for automatic test isolation, an import-time FastAPI compatibility guard, and a batch of correctness/DX fixes around graceful shutdown, the event-loop manager, and the public API surface.

### Highlights since v1.5.0

**Features**
- `feat: ship pytest plugin for test isolation` (#244) — auto-loaded via the `pytest11` entry point; resets the global dependency cache and exit stacks around every test by default (opt out with `injectable_autouse_cleanup = false`).
- `feat: add import-time FastAPI compatibility guard` (#243) — fails fast with a version-named `FastAPICompatibilityError` if FastAPI's private dependency-resolution API drifts.

**Fixes**
- `fix: make setup_graceful_shutdown terminate and chain signal handlers` (#239) — now chains pre-existing handlers and actually terminates after cleanup; new `install_signal_handlers` flag; degrades gracefully off the main thread.
- `fix: re-export configure_logging and public exceptions from the package root` (#242) — `configure_logging`, `DependencyCleanupError`, `RunCoroutineSyncMaxRetriesError` now importable from `fastapi_injectable`; the latter is now actually raised on retry exhaustion.
- `fix: re-check loop field inside lock to prevent leaked loops and threads` (#245) + clearer loop-strategy / resolution error messages (#246).
- `fix: accept classes and sync providers in async_get_injected_obj` (#237) — typed surface now matches `get_injected_obj()` (type-only).
- `fix(mypy): support @injectable(...) call form and keyword-only deps` (#240).

**Docs**
- `docs: make README examples runnable and document the worker happy path` (#241).

### Breaking changes

No hard API breaks — all public-API changes are additive and back-compat is preserved (`RunCoroutineSyncMaxRetriesError` subclasses `TimeoutError`). Two behavior changes worth noting on upgrade:
- The **pytest plugin auto-activates** and resets injectable global state around every test by default. Opt out with `injectable_autouse_cleanup = false`.
- **`setup_graceful_shutdown` now actually terminates** the process after cleanup (previously the signal was swallowed and the process kept running).
