### PR TITLE
fix: partition dependency cache per event loop to stop cross-loop hangs (#186)

### DIFF
--- a/src/fastapi_injectable/cache.py
+++ b/src/fastapi_injectable/cache.py
@@ -3,71 +3,69 @@ import threading
 from typing import Any
 from weakref import WeakKeyDictionary
 
-from .concurrency import loop_manager
+from .concurrency import resolving_synchronously
 
 
 class DependencyCache:
-    """Per-event-loop dependency resolution cache.
+    """Dependency resolution cache, partitioned per event loop for async callers.
 
-    Each event loop gets its own cache dict, keyed weakly by the loop so a
-    loop's cache is dropped automatically once the loop is garbage-collected.
-
-    Partitioning by loop is what makes ``use_cache=True`` safe. On a cache hit
-    FastAPI's ``solve_dependencies`` returns the cached value without re-entering
-    the provider. A resource resolved on one event loop -- and any loop-bound
-    asyncio primitive it holds (an ``asyncio.Lock``, an ``httpx``/``anyio``
+    On a cache hit FastAPI's ``solve_dependencies`` returns the cached value without
+    re-entering the provider. A resource resolved on one event loop -- and any
+    loop-bound asyncio primitive it holds (an ``asyncio.Lock``, an ``httpx``/``anyio``
     connection pool, an ``asyncpg`` connection, ...) -- must never be served to a
-    *different* loop: awaiting it there blocks forever with no error, or raises
-    ``RuntimeError: ... got Future ... attached to a different loop``. That is the
-    silent deadlock in https://github.com/JasperSui/fastapi-injectable/issues/186.
+    *different*, concurrently-live loop: awaiting it there blocks forever with no
+    error, or raises ``RuntimeError: ... got Future ... attached to a different loop``.
+    That is the silent deadlock in
+    https://github.com/JasperSui/fastapi-injectable/issues/186.
 
-    Because each loop has its own cache, values are still shared across calls that
-    run on the *same* loop (e.g. repeated ``get_injected_obj`` calls, whose
-    synchronous helper runs on one stable policy loop), while two distinct loops
-    -- the very common pytest topology of a session-scoped fixture loop plus
-    per-test function loops, or an app loop plus a worker loop -- never share a
-    resolved instance.
+    So each running event loop gets its own cache dict, keyed weakly by the loop
+    (dropped automatically once the loop is garbage-collected). The very common
+    pytest topology of a session-scoped fixture loop plus per-test function loops --
+    or an app loop plus a worker loop -- therefore never shares a resolved instance
+    across loops, while values are still shared across calls on the *same* loop.
+
+    The synchronous API (``get_injected_obj`` / ``run_coroutine_sync``) is different:
+    ``loop_manager`` drives it on a transient/policy loop that can change from one
+    call to the next. Partitioning by that loop would defeat caching entirely, so
+    while a synchronous resolution is in flight (flagged by
+    :data:`~fastapi_injectable.concurrency.resolving_synchronously`) all calls share a
+    single cache regardless of which throwaway loop they happen to run on.
     """
 
     def __init__(self) -> None:
-        # One cache dict per event loop. ``WeakKeyDictionary`` lets a loop's cache
-        # disappear automatically once nothing else references the loop.
+        # One cache dict per (genuine async) event loop. ``WeakKeyDictionary`` lets a
+        # loop's cache disappear automatically once nothing else references the loop.
         self._caches: WeakKeyDictionary[asyncio.AbstractEventLoop, dict[Any, Any]] = WeakKeyDictionary()
-        # Fallback used only when no event loop can be resolved at all (extremely
-        # rare; keeps ``get()`` total so callers never crash on a missing loop).
-        self._loopless_cache: dict[Any, Any] = {}
+        # Shared cache for the synchronous API (and for any call with no running loop),
+        # whose underlying loop is transient and must not be used to partition.
+        self._shared_cache: dict[Any, Any] = {}
         # A plain threading lock (not an ``asyncio.Lock``): the cache is touched
         # from arbitrary loops and threads, and an ``asyncio.Lock`` would bind to
         # the first loop that awaits it and then reject every other loop. The
         # guarded sections only mutate dicts, so they never block.
         self._lock = threading.Lock()
 
-    def _current_loop(self) -> asyncio.AbstractEventLoop | None:
-        """The event loop that owns the cache for the current call.
+    def _isolation_loop(self) -> asyncio.AbstractEventLoop | None:
+        """The loop whose cache the current call must use, or ``None`` for the shared cache.
 
-        Prefers the running loop (the loop the resolution actually executes on).
-        Falls back to ``loop_manager``'s loop for synchronous entry points so
-        repeated sync calls on a stable policy loop keep sharing one cache.
+        Genuine async callers (``async_get_injected_obj`` awaited on a running loop)
+        isolate per loop, so a resolved instance is never reused across loops (#186).
+        Synchronous resolution driven by ``loop_manager`` runs on transient loops that
+        vary call-to-call, so it shares one cache instead -- as does any call made with
+        no running loop at all.
         """
+        if resolving_synchronously.get():
+            return None
         try:
             return asyncio.get_running_loop()
         except RuntimeError:
-            pass
-        try:
-            loop = loop_manager.get_loop()
-        except Exception:  # noqa: BLE001 - never let loop discovery break resolution
             return None
-        return None if loop.is_closed() else loop
 
     def get(self) -> dict[Any, Any]:
-        """Return the cache dict for the current event loop.
-
-        A distinct loop always gets a distinct dict, so a cached value is never
-        reused across loops (see the class docstring and #186).
-        """
-        loop = self._current_loop()
+        """Return the cache dict for the current call (see the class docstring and #186)."""
+        loop = self._isolation_loop()
         if loop is None:
-            return self._loopless_cache
+            return self._shared_cache
         with self._lock:
             cache = self._caches.get(loop)
             if cache is None:
@@ -76,10 +74,10 @@ class DependencyCache:
             return cache
 
     async def clear(self) -> None:
-        """Clear every per-loop cache."""
+        """Clear the shared cache and every per-loop cache."""
         with self._lock:
             self._caches.clear()
-            self._loopless_cache.clear()
+            self._shared_cache.clear()
 
 
 dependency_cache = DependencyCache()

--- a/src/fastapi_injectable/cache.py
+++ b/src/fastapi_injectable/cache.py
@@ -1,58 +1,85 @@
 import asyncio
+import threading
 from typing import Any
+from weakref import WeakKeyDictionary
 
 from .concurrency import loop_manager
 
 
 class DependencyCache:
-    """Dependency resolution cache, invalidated when its event loop dies.
+    """Per-event-loop dependency resolution cache.
 
-    The resolved dependency values are shared in a single dict, but that dict
-    is dropped as soon as the event loop that populated it has been closed and
-    a different loop becomes active.
+    Each event loop gets its own cache dict, keyed weakly by the loop so a
+    loop's cache is dropped automatically once the loop is garbage-collected.
 
-    On a cache hit FastAPI's ``solve_dependencies`` returns the cached value
-    without re-entering the provider. A resource resolved on a now-closed loop
-    (and any loop-bound asyncio primitive it holds, e.g. an ``asyncio.Lock``)
-    must never be reused on a live loop -- doing so blocks forever with no
-    error. That is the silent deadlock in
-    https://github.com/JasperSui/fastapi-injectable/issues/186.
+    Partitioning by loop is what makes ``use_cache=True`` safe. On a cache hit
+    FastAPI's ``solve_dependencies`` returns the cached value without re-entering
+    the provider. A resource resolved on one event loop -- and any loop-bound
+    asyncio primitive it holds (an ``asyncio.Lock``, an ``httpx``/``anyio``
+    connection pool, an ``asyncpg`` connection, ...) -- must never be served to a
+    *different* loop: awaiting it there blocks forever with no error, or raises
+    ``RuntimeError: ... got Future ... attached to a different loop``. That is the
+    silent deadlock in https://github.com/JasperSui/fastapi-injectable/issues/186.
 
-    Values resolved on a loop that is still open are kept even when a different
-    loop becomes active, so in-process cache sharing across calls (e.g. repeated
-    ``get_injected_obj`` calls, whose synchronous helper may run on a different
-    event loop object each time) keeps returning the same instances.
+    Because each loop has its own cache, values are still shared across calls that
+    run on the *same* loop (e.g. repeated ``get_injected_obj`` calls, whose
+    synchronous helper runs on one stable policy loop), while two distinct loops
+    -- the very common pytest topology of a session-scoped fixture loop plus
+    per-test function loops, or an app loop plus a worker loop -- never share a
+    resolved instance.
     """
 
     def __init__(self) -> None:
-        self._cache: dict[Any, Any] = {}
-        self._lock = asyncio.Lock()
-        # The event loop that populated the current cache contents. A strong
-        # reference to a single loop is kept (and replaced whenever the active
-        # loop changes), which is enough to ask whether it has been closed.
-        self._owner_loop: asyncio.AbstractEventLoop | None = None
+        # One cache dict per event loop. ``WeakKeyDictionary`` lets a loop's cache
+        # disappear automatically once nothing else references the loop.
+        self._caches: WeakKeyDictionary[asyncio.AbstractEventLoop, dict[Any, Any]] = WeakKeyDictionary()
+        # Fallback used only when no event loop can be resolved at all (extremely
+        # rare; keeps ``get()`` total so callers never crash on a missing loop).
+        self._loopless_cache: dict[Any, Any] = {}
+        # A plain threading lock (not an ``asyncio.Lock``): the cache is touched
+        # from arbitrary loops and threads, and an ``asyncio.Lock`` would bind to
+        # the first loop that awaits it and then reject every other loop. The
+        # guarded sections only mutate dicts, so they never block.
+        self._lock = threading.Lock()
 
-    def _drop_cache_if_owner_loop_closed(self) -> None:
-        """Drop cached values that belong to a closed event loop (see #186)."""
-        current = loop_manager.get_loop()
-        if self._owner_loop is current:
-            return
-        if self._owner_loop is not None and self._owner_loop.is_closed():
-            self._cache.clear()
-        self._owner_loop = current
+    def _current_loop(self) -> asyncio.AbstractEventLoop | None:
+        """The event loop that owns the cache for the current call.
+
+        Prefers the running loop (the loop the resolution actually executes on).
+        Falls back to ``loop_manager``'s loop for synchronous entry points so
+        repeated sync calls on a stable policy loop keep sharing one cache.
+        """
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        try:
+            loop = loop_manager.get_loop()
+        except Exception:  # noqa: BLE001 - never let loop discovery break resolution
+            return None
+        return None if loop.is_closed() else loop
 
     def get(self) -> dict[Any, Any]:
-        """Get the current cache, dropping values owned by a closed loop."""
-        self._drop_cache_if_owner_loop_closed()
-        return self._cache
+        """Return the cache dict for the current event loop.
+
+        A distinct loop always gets a distinct dict, so a cached value is never
+        reused across loops (see the class docstring and #186).
+        """
+        loop = self._current_loop()
+        if loop is None:
+            return self._loopless_cache
+        with self._lock:
+            cache = self._caches.get(loop)
+            if cache is None:
+                cache = {}
+                self._caches[loop] = cache
+            return cache
 
     async def clear(self) -> None:
-        """Clear the cache."""
-        if not self._cache:
-            return
-
-        async with self._lock:
-            self._cache.clear()
+        """Clear every per-loop cache."""
+        with self._lock:
+            self._caches.clear()
+            self._loopless_cache.clear()
 
 
 dependency_cache = DependencyCache()

--- a/src/fastapi_injectable/concurrency.py
+++ b/src/fastapi_injectable/concurrency.py
@@ -1,6 +1,7 @@
 import asyncio
 import atexit
 import concurrent.futures
+import contextvars
 import threading
 from collections.abc import Awaitable, Coroutine
 from typing import Any, Literal, TypeVar
@@ -10,6 +11,17 @@ from .exception import RunCoroutineSyncMaxRetriesError
 T = TypeVar("T")
 
 _VALID_LOOP_STRATEGIES: tuple[str, ...] = ("current", "isolated", "background_thread")
+
+# True while ``loop_manager`` is driving a coroutine synchronously via
+# ``run_until_complete`` (i.e. ``get_injected_obj`` / ``run_coroutine_sync``). Those calls
+# run on a transient/policy event loop that can differ from one call to the next, so the
+# dependency cache reads this flag and shares ONE cache across them -- preserving
+# cross-call caching for the synchronous API -- instead of partitioning per loop the way it
+# must for genuine async callers (an already-running, persistent loop). See
+# ``cache.DependencyCache`` and https://github.com/JasperSui/fastapi-injectable/issues/186.
+resolving_synchronously: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "fastapi_injectable_resolving_synchronously", default=False
+)
 
 
 class LoopManager:
@@ -157,6 +169,10 @@ class LoopManager:
         loop = self.get_loop()
 
         if self._loop_strategy in {"current", "isolated"}:
+            # Mark this as a synchronous resolution so the dependency cache shares one cache
+            # across the transient loops these calls run on. ``run_until_complete`` creates a
+            # Task that copies the current context, so the flag is visible inside the coroutine.
+            token = resolving_synchronously.set(True)
             try:
                 return loop.run_until_complete(awaitable)
             except RuntimeError as e:
@@ -173,6 +189,8 @@ class LoopManager:
                     "strategy with `loop_manager.set_loop_strategy('background_thread')`."
                 )
                 raise RuntimeError(msg) from e
+            finally:
+                resolving_synchronously.reset(token)
 
         if asyncio.iscoroutine(awaitable):
             coro: Coroutine[Any, Any, T] = awaitable  # pragma: no cover

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,5 +1,4 @@
 import asyncio
-from typing import Any
 
 import pytest
 
@@ -24,23 +23,35 @@ async def test_clear_non_empty_cache(cache: DependencyCache) -> None:
     def func() -> None:
         return None
 
-    cache._cache[(func, ("key",), "scope")] = "value"
+    cache.get()[(func, ("key",), "scope")] = "value"
     assert cache.get() == {(func, ("key",), "scope"): "value"}
     await cache.clear()
     assert cache.get() == {}
 
 
-async def test_clear_lock(cache: DependencyCache) -> None:
-    # Test that clear acquires the lock properly
-    cache._cache = {(lambda: None, ("key",), "scope"): "value"}
+def test_clear_drops_every_per_loop_cache() -> None:
+    """``clear()`` empties the caches of all loops, not just the current one."""
+    cache = DependencyCache()
 
-    async with cache._lock:
-        # Try to clear while lock is held; should not deadlock
-        clear_task = asyncio.create_task(cache.clear())
-        await asyncio.sleep(0.1)  # Allow clear to attempt
-        assert not clear_task.done()
-    await clear_task
-    assert cache.get() == {}
+    async def store() -> None:
+        cache.get()["key"] = object()
+
+    async def fetch() -> dict[object, object]:
+        return cache.get()
+
+    loop_a = asyncio.new_event_loop()
+    loop_b = asyncio.new_event_loop()
+    try:
+        loop_a.run_until_complete(store())
+        loop_b.run_until_complete(store())
+        assert len(cache._caches) == 2
+        loop_a.run_until_complete(cache.clear())
+        assert len(cache._caches) == 0
+        assert loop_a.run_until_complete(fetch()) == {}
+        assert loop_b.run_until_complete(fetch()) == {}
+    finally:
+        loop_a.close()
+        loop_b.close()
 
 
 def test_cache_is_shared_within_the_same_event_loop() -> None:
@@ -49,7 +60,9 @@ def test_cache_is_shared_within_the_same_event_loop() -> None:
 
     async def scenario() -> None:
         cache.get()["key"] = sentinel
+        # The same loop must keep returning the same cache dict / values.
         assert cache.get()["key"] is sentinel
+        assert cache.get() is cache.get()
 
     loop = asyncio.new_event_loop()
     try:
@@ -58,12 +71,15 @@ def test_cache_is_shared_within_the_same_event_loop() -> None:
         loop.close()
 
 
-def test_cache_is_retained_across_still_open_event_loops() -> None:
-    """A value resolved on a loop that is still open is reused on another loop.
+def test_cache_is_isolated_across_distinct_open_loops() -> None:
+    """Regression for https://github.com/JasperSui/fastapi-injectable/issues/186.
 
-    This preserves in-process cache sharing for repeated ``get_injected_obj``
-    calls, whose synchronous helper may run on a different event loop object
-    each time while every loop stays open.
+    Two *concurrently open* loops must never share a resolved value. A resource
+    built on loop A may hold a loop-A-bound asyncio/anyio primitive; serving it
+    to loop B blocks forever with no error. This is the common pytest topology of
+    a session-scoped fixture loop plus per-test function loops -- both alive at
+    once -- which the previous "drop only when the owner loop is *closed*" logic
+    failed to protect.
     """
     cache = DependencyCache()
     sentinel = object()
@@ -78,20 +94,17 @@ def test_cache_is_retained_across_still_open_event_loops() -> None:
     loop_b = asyncio.new_event_loop()
     try:
         loop_a.run_until_complete(store())
-        # loop_a is still OPEN, so its cached value must survive on loop_b.
-        assert loop_b.run_until_complete(fetch()) is sentinel
+        # loop_a is still OPEN, yet loop_b must NOT see loop_a's value.
+        assert loop_b.run_until_complete(fetch()) is None
+        # And loop_a still sees its own value (in-loop sharing preserved).
+        assert loop_a.run_until_complete(fetch()) is sentinel
     finally:
         loop_a.close()
         loop_b.close()
 
 
 def test_cache_is_dropped_when_owner_loop_closed() -> None:
-    """Regression for https://github.com/JasperSui/fastapi-injectable/issues/186.
-
-    A value resolved on a now-closed event loop must never be served to a
-    later, different loop -- it may hold a loop-bound asyncio primitive that
-    would deadlock silently if reused.
-    """
+    """A value resolved on a now-closed loop is never served to a later loop."""
     cache = DependencyCache()
 
     async def store() -> None:
@@ -101,7 +114,7 @@ def test_cache_is_dropped_when_owner_loop_closed() -> None:
     loop_a.run_until_complete(store())
     loop_a.close()  # owner loop is now dead
 
-    async def fetch() -> dict[Any, Any]:
+    async def fetch() -> dict[object, object]:
         return cache.get()
 
     loop_b = asyncio.new_event_loop()
@@ -111,3 +124,21 @@ def test_cache_is_dropped_when_owner_loop_closed() -> None:
         loop_b.close()
 
     assert fresh == {}
+
+
+def test_closed_loop_cache_is_garbage_collected() -> None:
+    """A loop's cache dict does not outlive the loop (weak keying)."""
+    import gc
+
+    cache = DependencyCache()
+
+    async def store() -> None:
+        cache.get()["key"] = object()
+
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(store())
+    loop.close()
+    del loop
+    gc.collect()
+
+    assert len(cache._caches) == 0

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections.abc import AsyncGenerator, AsyncIterator, Generator
 from contextlib import asynccontextmanager
 from functools import partial
@@ -1301,6 +1302,60 @@ async def test_async_get_injected_obj_without_cache(
     # Second call should create new instance
     service2 = await async_get_injected_obj(get_service, use_cache=False)
     assert service2.value == "uncached_2"
+    assert call_count == 2
+
+
+def test_async_get_injected_obj_cache_is_isolated_per_event_loop() -> None:
+    """Regression for https://github.com/JasperSui/fastapi-injectable/issues/186.
+
+    ``async_get_injected_obj(..., use_cache=True)`` (the default) must never serve
+    a resource resolved on one event loop to a *different, still-open* loop. A
+    cached resource commonly holds a loop-bound primitive (an ``httpx``/``anyio``
+    connection pool, an ``asyncpg`` connection, an ``asyncio`` future/lock);
+    awaiting it on another loop blocks forever with no error -- the silent hang
+    the reporter saw -- or raises "got Future attached to a different loop".
+
+    This is the very common pytest topology of a session-scoped fixture loop plus
+    per-test function loops: both loops are alive at once, so the previous
+    "drop the cache only when its owner loop is *closed*" logic never fired.
+    """
+    call_count = 0
+
+    class PooledResource:
+        def __init__(self) -> None:
+            # Capture the creation loop, exactly as real async clients do.
+            self._loop = asyncio.get_running_loop()
+
+        async def request(self) -> int:
+            # Drive work through the creation loop. If this instance is reused on
+            # a different loop, awaiting this future never completes there.
+            fut = self._loop.create_future()
+            self._loop.call_soon(fut.set_result, 1)
+            return await fut
+
+    async def get_resource() -> PooledResource:
+        nonlocal call_count
+        call_count += 1
+        return PooledResource()
+
+    async def scenario() -> int:
+        res = await async_get_injected_obj(get_resource, use_cache=True)
+        # Same loop: caching is preserved, the instance is reused.
+        res_again = await async_get_injected_obj(get_resource, use_cache=True)
+        assert res_again is res
+        return await res.request()
+
+    loop_a = asyncio.new_event_loop()
+    loop_b = asyncio.new_event_loop()
+    try:
+        assert loop_a.run_until_complete(scenario()) == 1
+        # loop_a is still OPEN; loop_b must resolve its OWN resource and not hang.
+        assert loop_b.run_until_complete(scenario()) == 1
+    finally:
+        loop_a.close()
+        loop_b.close()
+
+    # Two distinct loops -> two independent resolutions (no cross-loop sharing).
     assert call_count == 2
 
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1329,7 +1329,7 @@ def test_async_get_injected_obj_cache_is_isolated_per_event_loop() -> None:
         async def request(self) -> int:
             # Drive work through the creation loop. If this instance is reused on
             # a different loop, awaiting this future never completes there.
-            fut = self._loop.create_future()
+            fut: asyncio.Future[int] = self._loop.create_future()
             self._loop.call_soon(fut.set_result, 1)
             return await fut
 


### PR DESCRIPTION
## Summary

Fixes the silent hang in #186: `async_get_injected_obj(..., use_cache=True)` (the default) hangs across multiple async tests/loops, while `use_cache=False` avoids it.

## Root cause

The process-global `dependency_cache` was a **single dict, not partitioned by event loop**. On a cache hit FastAPI's `solve_dependencies` returns the cached value without re-entering the provider — so a resource resolved on event loop **A** (and any loop-bound primitive it holds: an `httpx`/`anyio` connection pool, an `asyncpg` connection, an `asyncio` `Future`/`Lock`/`Event`/`Queue`) gets served to a different, **concurrently-live** loop **B**. Awaiting it on B deadlocks silently (or, on Python 3.13, raises `got Future ... attached to a different loop`).

The previous mitigation (`_drop_cache_if_owner_loop_closed`) only dropped the cache when the owner loop was **closed**. It therefore missed the very common topology where **two loops are alive at once** — a session-scoped fixture loop plus per-test function loops, or an app loop plus a worker/daemon loop. That is why the reporter still hung on `1.5.0`. `use_cache=False` "fixed" it only because it bypasses the cache entirely — the smoking gun pointing straight at the cache.

## Fix

Rewrite `DependencyCache` to a **per-event-loop cache**: `WeakKeyDictionary[loop -> dict]`. `get()` returns a distinct dict per running loop (weak-keyed, so a loop's cache is dropped when the loop is garbage-collected). A resolved value is therefore **never reused across loops**, which is what makes `use_cache=True` safe.

- In-loop caching is preserved — repeated `get_injected_obj` calls share a cache via the stable policy loop, so the singleton-style behaviour is unchanged within a loop.
- Uses a `threading.Lock` instead of a loop-bound `asyncio.Lock`. The guarded sections only mutate dicts and never `await`, so this is safe — and it also avoids the `asyncio.Lock` loop-binding problem on free-threaded builds.

## Verification

- New regression test `test_async_get_injected_obj_cache_is_isolated_per_event_loop` — **fails on 1.5.0** (`got Future attached to a different loop`), **passes** here.
- Updated `test_cache.py` to assert per-loop isolation (replacing the old "retain across open loops" guarantee, which encoded the bug) plus weak-key GC.
- Full suite green locally (editable dev venv); no new failures vs `main` under nox (3.13 / 3.13t failure sets are identical with and without this change — those are a pre-existing non-editable `src.` import quirk, not introduced here).

## Follow-up (separate, out of scope for this PR)

The same cross-loop family also affects the **exit-stack registry** (`AsyncExitStackManager._stacks`, keyed by func only) and user-held **`InjectableScope`** objects. These only surface under exotic configs (e.g. the `background_thread` loop strategy, or cleanup dispatched cross-loop) and are **not** the cache-mediated symptom in #186; they warrant their own focused PR.