### PR TITLE
fix: partition exit-stack registry by owning event loop (#186 follow-up)

### DIFF
--- a/src/fastapi_injectable/async_exit_stack.py
+++ b/src/fastapi_injectable/async_exit_stack.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 from collections.abc import Callable
 from contextlib import AsyncExitStack
 from typing import Any
@@ -8,28 +9,98 @@ from .concurrency import loop_manager
 from .exception import DependencyCleanupError
 from .logging import logger
 
+_Loop = asyncio.AbstractEventLoop
+
 
 class AsyncExitStackManager:
+    """Per-event-loop registry of dependency exit stacks.
+
+    A stack is entered while resolving a dependency on a particular event loop,
+    and it owns that dependency's async-generator teardowns. Those teardowns may
+    ``await`` loop-bound primitives (an ``asyncio.Future``/``Event``/``Lock``, an
+    ``httpx``/``anyio`` connection pool, an ``asyncpg`` connection, ...). Such a
+    stack must therefore be closed on the *same* loop it was entered on: closing
+    it on a different loop awaits a loop-A primitive from loop B, which on Python
+    3.13+ raises ``RuntimeError: ... attached to a different loop`` and on older
+    runtimes (or behind a no-guard suspend point) hangs forever. That is the
+    exit-stack half of https://github.com/JasperSui/fastapi-injectable/issues/186.
+
+    The registry is keyed first by the owning loop (weakly, so a loop's stacks
+    disappear once the loop is gone) and then by the provider function (weakly, to
+    preserve provider-garbage-collection cleanup). Cleanup dispatches each stack's
+    ``aclose()`` back onto its owning loop; a stack whose loop has already died is
+    dropped (its resources are dead anyway) rather than closed cross-loop.
+    """
+
     def __init__(self) -> None:
-        self._stacks: WeakKeyDictionary[Callable[..., Any], AsyncExitStack] = WeakKeyDictionary()
-        self._lock = asyncio.Lock()
+        self._stacks: WeakKeyDictionary[_Loop, WeakKeyDictionary[Callable[..., Any], AsyncExitStack]] = (
+            WeakKeyDictionary()
+        )
+        # A plain threading.Lock (not an asyncio.Lock). The lock guards only the
+        # synchronous registry mutations below; every ``await stack.aclose()`` runs
+        # OUTSIDE the lock (the stack is popped from the registry first), so the
+        # lock never spans an await -- it can never block a loop, and it works
+        # across loops and free-threaded builds. An asyncio.Lock would instead bind
+        # to the first loop that awaited it and reject the other concurrently-live
+        # loop that drives cross-loop cleanup.
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _running_loop() -> _Loop | None:
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+
+    def _owning_loop(self) -> _Loop:
+        """The loop a stack created *now* belongs to (the loop resolution runs on)."""
+        running = self._running_loop()
+        if running is not None:
+            return running
+        return loop_manager.get_loop()
 
     async def get_stack(self, func: Callable[..., Any]) -> AsyncExitStack:
-        """Retrieve or create a stack and loop for managing async resources.
+        """Retrieve or create the exit stack for ``func`` on the current event loop.
 
         Args:
             func: The function to associate with an exit stack
 
         Returns:
-            AsyncExitStack: The exit stack for the given function
+            AsyncExitStack: The exit stack for the given function on this loop
         """
-        async with self._lock:
-            if func not in self._stacks:
-                self._stacks[func] = AsyncExitStack()
-            return self._stacks[func]
+        loop = self._owning_loop()
+        with self._lock:
+            per_loop = self._stacks.get(loop)
+            if per_loop is None:
+                per_loop = WeakKeyDictionary()
+                self._stacks[loop] = per_loop
+            stack = per_loop.get(func)
+            if stack is None:
+                stack = AsyncExitStack()
+                per_loop[func] = stack
+            return stack
+
+    async def _close_stack(self, loop: _Loop, stack: AsyncExitStack) -> None:
+        """Close one stack on its owning loop.
+
+        - owning loop is the current running loop -> close it here directly;
+        - owning loop is alive and running in another thread -> dispatch the close
+          onto it and await the result without blocking this loop;
+        - owning loop is closed or no longer running -> its async-generator
+          resources are already dead; drop the stack instead of closing it
+          cross-loop (which would hang or raise "attached to a different loop").
+        """
+        running = self._running_loop()
+        if loop is running:
+            await stack.aclose()
+            return
+        if loop.is_closed() or not loop.is_running():
+            return
+        future = asyncio.run_coroutine_threadsafe(stack.aclose(), loop)
+        await asyncio.wrap_future(future)
 
     async def cleanup_stack(self, func: Callable[..., Any], *, raise_exception: bool = False) -> None:
-        """Clean up the stack associated with the given function.
+        """Clean up the stack(s) associated with the given function.
 
         Args:
             func: The function whose exit stack should be cleaned up
@@ -38,34 +109,37 @@ class AsyncExitStackManager:
         Raises:
             DependencyCleanupError: When cleanup fails and raise_exception is True
         """
-        if not self._stacks:
-            return  # pragma: no cover
-
         original_func = getattr(func, "__original_func__", func)
-        exception_: Exception | None = None
-        async with self._lock:
-            stack = self._stacks.pop(original_func, None)
-            if not stack:
-                return  # pragma: no cover
-            try:
-                if loop_manager.in_loop():
-                    await stack.aclose()
-                else:
-                    loop_manager.run_in_loop(stack.aclose())  # pragma: no cover
-            except RuntimeError as e:
-                msg = f"Failed to cleanup stack for {func.__name__} during teardown: {e}"
-                logger.warning(msg)
-                exception_ = e
-            except Exception as e:  # noqa: BLE001 # pragma: no cover
-                msg = f"Failed to cleanup stack for {func.__name__}"
-                logger.exception(msg)
-                exception_ = e
 
-        if exception_ and raise_exception:
+        with self._lock:
+            entries: list[tuple[_Loop, AsyncExitStack]] = []
+            for _loop, per_loop in self._stacks.items():
+                stack = per_loop.pop(original_func, None)
+                if stack is not None:
+                    entries.append((_loop, stack))
+            self._prune_empty_locked()
+
+        if not entries:
+            return
+
+        exception_: Exception | None = None
+        msg = ""
+        try:
+            await asyncio.gather(*(self._close_stack(loop, stack) for loop, stack in entries))
+        except RuntimeError as e:
+            msg = f"Failed to cleanup stack for {func.__name__} during teardown: {e}"
+            logger.warning(msg)
+            exception_ = e
+        except Exception as e:  # noqa: BLE001
+            msg = f"Failed to cleanup stack for {func.__name__}"
+            logger.exception(msg)
+            exception_ = e
+
+        if exception_ is not None and raise_exception:
             raise DependencyCleanupError(msg) from exception_
 
     async def cleanup_all_stacks(self, *, raise_exception: bool = False) -> None:
-        """Clean up all stacks.
+        """Clean up all stacks, each on its own owning loop.
 
         Args:
             raise_exception: If True, raises DependencyCleanupError when any cleanup fails
@@ -73,41 +147,34 @@ class AsyncExitStackManager:
         Raises:
             DependencyCleanupError: When any cleanup fails and raise_exception is True
         """
-        if not self._stacks:
+        with self._lock:
+            entries = [(loop, stack) for loop, per_loop in self._stacks.items() for stack in per_loop.values()]
+            self._stacks.clear()
+
+        if not entries:
             return
 
         exception_: Exception | None = None
-        async with self._lock:
-            tasks = [stack.aclose() for stack in self._stacks.values()]
-            self._stacks.clear()
+        msg = ""
+        try:
+            await asyncio.gather(*(self._close_stack(loop, stack) for loop, stack in entries))
+        except RuntimeError as e:
+            msg = f"Failed to cleanup one or more dependency stacks during teardown: {e}"
+            logger.warning(msg)
+            exception_ = e
+        except Exception as e:  # noqa: BLE001
+            msg = "Failed to cleanup one or more dependency stacks"
+            logger.exception(msg)
+            exception_ = e
 
-            if not tasks:
-                return  # pragma: no cover
-
-            try:
-                if loop_manager.in_loop():
-                    await asyncio.gather(*tasks)
-                else:
-
-                    async def _wrapper() -> None:  # pragma: no cover
-                        """Wrapper to run the gather in the correct loop."""
-                        await asyncio.gather(*tasks)
-
-                    # If we use loop_manager.run_in_loop(asyncio.gather(*tasks)),
-                    # the gather future will be awaited in the current loop, not the loop in the loop_manager.
-                    # then it will raise an RuntimeError(got Future <_GatheringFuture pending> attached to a different loop)  # noqa: E501
-                    loop_manager.run_in_loop(_wrapper())  # pragma: no cover
-            except RuntimeError as e:
-                msg = f"Failed to cleanup one or more dependency stacks during teardown: {e}"
-                logger.warning(msg)
-                exception_ = e
-            except Exception as e:  # noqa: BLE001 # pragma: no cover
-                msg = "Failed to cleanup one or more dependency stacks"
-                logger.exception(msg)
-                exception_ = e
-
-        if exception_ and raise_exception:
+        if exception_ is not None and raise_exception:
             raise DependencyCleanupError(msg) from exception_
+
+    def _prune_empty_locked(self) -> None:
+        """Drop now-empty per-loop sub-registries. Caller must hold ``self._lock``."""
+        empty = [loop for loop, per_loop in self._stacks.items() if not per_loop]
+        for loop in empty:
+            del self._stacks[loop]
 
 
 async_exit_stack_manager = AsyncExitStackManager()

--- a/test/test_async_exit_stack.py
+++ b/test/test_async_exit_stack.py
@@ -1,11 +1,14 @@
 import asyncio
+import gc
+from collections.abc import Callable
 from contextlib import AsyncExitStack
-from unittest.mock import AsyncMock, Mock, patch
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+from weakref import WeakKeyDictionary
 
 import pytest
 
 from fastapi_injectable.async_exit_stack import AsyncExitStackManager
-from fastapi_injectable.concurrency import LoopManager
 from fastapi_injectable.exception import DependencyCleanupError
 
 
@@ -28,71 +31,54 @@ def mock_stack() -> AsyncMock:
     return mock
 
 
-def create_mocked_loop_manager() -> Mock:
-    mock = Mock(spec=LoopManager)
-    mock.in_loop.return_value = True
-    return mock
+def _register(manager: AsyncExitStackManager, func: Callable[..., Any], stack: AsyncExitStack) -> None:
+    """Register ``stack`` for ``func`` under the current running loop (the owner)."""
+    loop = asyncio.get_running_loop()
+    per_loop = manager._stacks.get(loop)
+    if per_loop is None:
+        per_loop = WeakKeyDictionary()
+        manager._stacks[loop] = per_loop
+    per_loop[func] = stack
+
+
+def _contains(manager: AsyncExitStackManager, func: object) -> bool:
+    return any(func in per_loop for per_loop in manager._stacks.values())
 
 
 async def test_get_stack_creates_new_stack(manager: AsyncExitStackManager, mock_func: Mock) -> None:
     stack = await manager.get_stack(mock_func)
     assert isinstance(stack, AsyncExitStack)
-    assert mock_func in manager._stacks
-    assert manager._stacks[mock_func] is stack
+    # Stored under the current event loop (the loop the resolution runs on).
+    loop = asyncio.get_running_loop()
+    assert manager._stacks[loop][mock_func] is stack
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
-async def test_cleanup_stack_with_existing_func_in_loop(
-    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+async def test_get_stack_returns_same_stack_for_same_func(manager: AsyncExitStackManager, mock_func: Mock) -> None:
+    first = await manager.get_stack(mock_func)
+    second = await manager.get_stack(mock_func)
+    assert first is second
+
+
+async def test_cleanup_stack_closes_and_removes_current_loop_stack(
+    manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
 ) -> None:
-    manager._stacks[mock_func] = mock_stack
+    _register(manager, mock_func, mock_stack)
     await manager.cleanup_stack(mock_func)
 
-    mock_loop_manager.in_loop.assert_called_once()
-    assert mock_func not in manager._stacks
+    mock_stack.aclose.assert_awaited_once()
+    assert not _contains(manager, mock_func)
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
-async def test_cleanup_stack_with_existing_func_not_in_loop(
-    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
-) -> None:
-    manager._stacks[mock_func] = mock_stack
-    mock_loop_manager.in_loop.return_value = False
-    await manager.cleanup_stack(mock_func)
-
-    mock_loop_manager.in_loop.assert_called_once()
-    mock_loop_manager.run_in_loop.assert_called_once()
-    assert mock_func not in manager._stacks
-
-
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
-async def test_cleanup_stack_with_empty_stacks(
-    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
-) -> None:
+async def test_cleanup_stack_with_empty_stacks(manager: AsyncExitStackManager, mock_func: Mock) -> None:
     await manager.cleanup_stack(mock_func)
     assert len(manager._stacks) == 0
-    mock_loop_manager.in_loop.assert_not_called()
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
 async def test_cleanup_stack_with_existing_func_raise_exception(
-    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+    manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
 ) -> None:
-    manager._stacks[mock_func] = mock_stack
-    mock_loop_manager.in_loop.return_value = False
-    mock_loop_manager.run_in_loop.side_effect = Exception("Cleanup failed")
+    mock_stack.aclose.side_effect = Exception("Cleanup failed")
+    _register(manager, mock_func, mock_stack)
 
     # NOTE: We don't use pytest.raises(DependencyCleanupError) because it's not working somehow,
     # so we use Exception instead, and check the exception type in the assert.
@@ -100,95 +86,91 @@ async def test_cleanup_stack_with_existing_func_raise_exception(
         await manager.cleanup_stack(mock_func, raise_exception=True)
 
     assert isinstance(exc_info.value, DependencyCleanupError)
-
-    mock_loop_manager.run_in_loop.assert_called_once()
-    assert mock_func not in manager._stacks
+    assert not _contains(manager, mock_func)
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
-async def test_cleanup_stack_with_nonexistent_func(
-    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock
-) -> None:
+async def test_cleanup_stack_with_nonexistent_func(manager: AsyncExitStackManager, mock_func: Mock) -> None:
     await manager.cleanup_stack(mock_func)
-    assert mock_func not in manager._stacks
-    mock_loop_manager.in_loop.assert_not_called()
+    assert not _contains(manager, mock_func)
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
 async def test_cleanup_stack_with_decorated_func(
-    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+    manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
 ) -> None:
-    # Simulate a decorated function
+    # Simulate a decorated function whose __original_func__ keys the registry.
     decorated_func = Mock()
     decorated_func.__original_func__ = mock_func
 
-    manager._stacks[mock_func] = mock_stack
+    _register(manager, mock_func, mock_stack)
     await manager.cleanup_stack(decorated_func)
-    mock_loop_manager.in_loop.assert_called_once()
-    assert mock_func not in manager._stacks
+
+    mock_stack.aclose.assert_awaited_once()
+    assert not _contains(manager, mock_func)
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
-async def test_cleanup_all_stacks_with_stacks(
-    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+async def test_cleanup_stack_skips_loops_without_target_func(
+    manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
 ) -> None:
-    manager._stacks[mock_func] = mock_stack
-    manager._stacks[Mock()] = AsyncMock(spec=AsyncExitStack)
+    """cleanup_stack only closes the target func; loops that don't hold it are left intact."""
+    idle_loop = asyncio.new_event_loop()
+    other_func = Mock()
+    other_func.__name__ = "other_func"
+    other_stack = AsyncMock(spec=AsyncExitStack)
+    other_stack.aclose.return_value = None
+    try:
+        _register(manager, mock_func, mock_stack)  # under the current loop
+        per_loop: WeakKeyDictionary[Any, Any] = WeakKeyDictionary()
+        per_loop[other_func] = other_stack
+        manager._stacks[idle_loop] = per_loop  # a different loop, different func
+
+        await manager.cleanup_stack(mock_func)
+
+        mock_stack.aclose.assert_awaited_once()
+        other_stack.aclose.assert_not_awaited()
+        assert other_func in manager._stacks[idle_loop]
+    finally:
+        idle_loop.close()
+
+
+async def test_cleanup_all_stacks_with_stacks(
+    manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+) -> None:
+    other_func = Mock()
+    other_func.__name__ = "other_func"
+    other_stack = AsyncMock(spec=AsyncExitStack)
+    other_stack.aclose.return_value = None
+    _register(manager, mock_func, mock_stack)
+    _register(manager, other_func, other_stack)
 
     await manager.cleanup_all_stacks()
 
     assert len(manager._stacks) == 0
-    mock_loop_manager.in_loop.assert_called_once()
+    mock_stack.aclose.assert_awaited_once()
+    other_stack.aclose.assert_awaited_once()
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
-async def test_cleanup_all_stacks_with_no_stacks(
-    mock_loop_manager: Mock,
-    manager: AsyncExitStackManager,
-) -> None:
+async def test_cleanup_all_stacks_with_no_stacks(manager: AsyncExitStackManager) -> None:
     await manager.cleanup_all_stacks()
-    mock_loop_manager.in_loop.assert_not_called()
+    assert len(manager._stacks) == 0
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
 async def test_cleanup_all_stacks_with_error(
-    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+    manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
 ) -> None:
-    manager._stacks[mock_func] = mock_stack
-    mock_loop_manager.run_in_loop.side_effect = Exception("Cleanup failed")
+    mock_stack.aclose.side_effect = Exception("Cleanup failed")
+    _register(manager, mock_func, mock_stack)
 
     # Since raise_exception=False, we should not expect an exception
     await manager.cleanup_all_stacks(raise_exception=False)
 
     assert len(manager._stacks) == 0
-    mock_loop_manager.in_loop.assert_called_once()
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
 async def test_cleanup_all_stacks_with_error_raise_exception(
-    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+    manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
 ) -> None:
-    manager._stacks[mock_func] = mock_stack
-    mock_loop_manager.in_loop.return_value = False
-    mock_loop_manager.run_in_loop.side_effect = Exception("Cleanup failed")
+    mock_stack.aclose.side_effect = Exception("Cleanup failed")
+    _register(manager, mock_func, mock_stack)
 
     # NOTE: We don't use pytest.raises(DependencyCleanupError) because it's not working somehow,
     # so we use Exception instead, and check the exception type in the assert.
@@ -197,29 +179,19 @@ async def test_cleanup_all_stacks_with_error_raise_exception(
 
     assert isinstance(exc_info.value, DependencyCleanupError)
     assert len(manager._stacks) == 0
-    mock_loop_manager.in_loop.assert_called_once()
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
-async def test_cleanup_all_stacks_with_empty_stacks(mock_loop_manager: Mock, manager: AsyncExitStackManager) -> None:
+async def test_cleanup_all_stacks_with_empty_stacks(manager: AsyncExitStackManager) -> None:
     await manager.cleanup_all_stacks()
     assert len(manager._stacks) == 0
-    mock_loop_manager.in_loop.assert_not_called()
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
 async def test_cleanup_stack_runtime_error_names_func_not_loop(
-    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+    manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
 ) -> None:
     """A RuntimeError raised during teardown is reported against the func, not blamed on the loop."""
     mock_stack.aclose.side_effect = RuntimeError("teardown boom")
-    manager._stacks[mock_func] = mock_stack
+    _register(manager, mock_func, mock_stack)
 
     with pytest.raises(Exception, match="teardown boom") as exc_info:
         await manager.cleanup_stack(mock_func, raise_exception=True)
@@ -231,16 +203,12 @@ async def test_cleanup_stack_runtime_error_names_func_not_loop(
     assert isinstance(exc_info.value.__cause__, RuntimeError)
 
 
-@patch(
-    "fastapi_injectable.async_exit_stack.loop_manager",
-    new_callable=create_mocked_loop_manager,
-)
 async def test_cleanup_all_stacks_runtime_error_names_error_not_loop(
-    mock_loop_manager: Mock, manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+    manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
 ) -> None:
     """A RuntimeError during teardown of all stacks reports the underlying error, not the loop."""
     mock_stack.aclose.side_effect = RuntimeError("teardown boom")
-    manager._stacks[mock_func] = mock_stack
+    _register(manager, mock_func, mock_stack)
 
     with pytest.raises(Exception, match="teardown boom") as exc_info:
         await manager.cleanup_all_stacks(raise_exception=True)
@@ -251,12 +219,39 @@ async def test_cleanup_all_stacks_runtime_error_names_error_not_loop(
     assert isinstance(exc_info.value.__cause__, RuntimeError)
 
 
+async def test_cleanup_drops_stack_owned_by_idle_non_current_loop(
+    manager: AsyncExitStackManager, mock_func: Mock, mock_stack: AsyncMock
+) -> None:
+    """A stack owned by a loop that is neither current nor running is dropped, not closed."""
+    idle_loop = asyncio.new_event_loop()  # open, never running, not the current loop
+    try:
+        per_loop: WeakKeyDictionary[Any, Any] = WeakKeyDictionary()
+        per_loop[mock_func] = mock_stack
+        manager._stacks[idle_loop] = per_loop
+
+        await manager.cleanup_all_stacks(raise_exception=True)
+
+        mock_stack.aclose.assert_not_awaited()
+        assert len(manager._stacks) == 0
+    finally:
+        idle_loop.close()
+
+
+def test_owning_loop_falls_back_to_loop_manager_without_running_loop(manager: AsyncExitStackManager) -> None:
+    """Outside any running loop, the owning loop comes from ``loop_manager`` (sync entry points)."""
+    assert manager._running_loop() is None
+    # With no running loop, _owning_loop() defers to loop_manager (the sync-entry loop).
+    owning = manager._owning_loop()
+    assert isinstance(owning, asyncio.AbstractEventLoop)
+
+
 async def test_concurrent_get_stack_access(manager: AsyncExitStackManager, mock_func: Mock) -> None:
     tasks = [manager.get_stack(mock_func) for _ in range(5)]
     stacks = await asyncio.gather(*tasks)
 
     assert all(stack is stacks[0] for stack in stacks)
-    assert len(manager._stacks) == 1
+    loop = asyncio.get_running_loop()
+    assert len(manager._stacks[loop]) == 1
 
 
 async def test_weakref_cleanup(manager: AsyncExitStackManager) -> None:
@@ -265,13 +260,12 @@ async def test_weakref_cleanup(manager: AsyncExitStackManager) -> None:
             pass
 
     temp = Temporary()
+    loop = asyncio.get_running_loop()
     stack = await manager.get_stack(temp)  # noqa: F841
-    assert temp in manager._stacks
+    assert temp in manager._stacks[loop]
 
     del temp
-    # Force garbage collection to ensure weak reference is cleaned up
-    import gc
-
+    # Force garbage collection to ensure the weak reference is cleaned up.
     gc.collect()
 
-    assert len(manager._stacks) == 0
+    assert len(manager._stacks[loop]) == 0

--- a/test/test_async_exit_stack_loop_partition.py
+++ b/test/test_async_exit_stack_loop_partition.py
@@ -1,0 +1,146 @@
+"""Regression tests for cross-event-loop exit-stack cleanup (issue #186 follow-up A).
+
+The exit-stack registry must be partitioned by the event loop each async-generator
+dependency was *entered* on. A stack entered while resolving on loop A holds that
+loop's teardown coroutines, which may ``await`` loop-A-bound primitives (an
+``asyncio.Future``/``Event``/``Lock``, an ``httpx``/``anyio`` pool, ...). Closing such
+a stack on a *different* loop awaits a loop-A primitive from the wrong loop, which on
+Python 3.13+ raises ``RuntimeError: ... attached to a different loop`` and on older
+runtimes (or behind a no-guard suspend point) hangs forever.
+"""
+
+import asyncio
+import threading
+from collections.abc import Iterator
+from contextlib import suppress
+
+import pytest
+
+from fastapi_injectable.async_exit_stack import AsyncExitStackManager
+
+
+def _provider() -> None:  # marker object used only as a registry key
+    raise NotImplementedError
+
+
+_provider.__name__ = "provider"
+
+
+def _run_loop_forever(loop: asyncio.AbstractEventLoop, ready: threading.Event) -> None:
+    asyncio.set_event_loop(loop)
+    loop.call_soon(ready.set)
+    loop.run_forever()
+
+
+@pytest.fixture
+def background_loop() -> Iterator[asyncio.AbstractEventLoop]:
+    """A second event loop running forever in its own (daemon) thread."""
+    loop = asyncio.new_event_loop()
+    ready = threading.Event()
+    thread = threading.Thread(target=_run_loop_forever, args=(loop, ready), daemon=True)
+    thread.start()
+    ready.wait(timeout=5)
+    yield loop
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5)
+    loop.close()
+
+
+async def test_cleanup_all_stacks_runs_teardown_on_its_owning_loop(
+    background_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """A stack entered on loop A is torn down on loop A, even when cleanup runs on loop B."""
+    manager = AsyncExitStackManager()
+    state: dict[str, object] = {}
+
+    async def _enter_on_loop_a() -> None:
+        # A pending future bound to loop A; resolved a little later *by loop A*.
+        owned_future = background_loop.create_future()
+        background_loop.call_later(0.05, owned_future.set_result, "ok")
+
+        stack = await manager.get_stack(_provider)
+
+        async def _teardown() -> None:
+            state["teardown_loop"] = asyncio.get_running_loop()
+            # Awaiting a loop-A future on the wrong loop raises immediately (3.13+)
+            # or hangs; on loop A it resolves cleanly.
+            await owned_future
+            state["done"] = True
+
+        stack.push_async_callback(_teardown)
+
+    # Enter the async resource on loop A.
+    asyncio.run_coroutine_threadsafe(_enter_on_loop_a(), background_loop).result(timeout=5)
+
+    # Trigger cleanup from loop B (this test's loop). The owning loop (A) is alive
+    # and running in another thread, so the close must be dispatched onto it.
+    await asyncio.wait_for(manager.cleanup_all_stacks(raise_exception=True), timeout=10)
+
+    assert state.get("done") is True
+    assert state["teardown_loop"] is background_loop
+
+
+async def test_cleanup_stack_runs_teardown_on_its_owning_loop(
+    background_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """The single-func cleanup path also tears down on the owning loop."""
+    manager = AsyncExitStackManager()
+    state: dict[str, object] = {}
+
+    async def _enter_on_loop_a() -> None:
+        owned_future = background_loop.create_future()
+        background_loop.call_later(0.05, owned_future.set_result, "ok")
+        stack = await manager.get_stack(_provider)
+
+        async def _teardown() -> None:
+            state["teardown_loop"] = asyncio.get_running_loop()
+            await owned_future
+            state["done"] = True
+
+        stack.push_async_callback(_teardown)
+
+    asyncio.run_coroutine_threadsafe(_enter_on_loop_a(), background_loop).result(timeout=5)
+
+    await asyncio.wait_for(manager.cleanup_stack(_provider, raise_exception=True), timeout=10)
+
+    assert state.get("done") is True
+    assert state["teardown_loop"] is background_loop
+
+
+async def test_cleanup_all_stacks_drops_stack_when_owning_loop_is_closed() -> None:
+    """When the owning loop is already closed, its resources are dead: drop, never block."""
+    manager = AsyncExitStackManager()
+    teardown_ran = {"value": False}
+    holder: dict[str, asyncio.AbstractEventLoop] = {}
+
+    def _setup_then_close_loop() -> None:
+        # Enter the stack on a loop in this worker thread, then close that loop,
+        # so the owning loop is already dead by the time cleanup runs on loop B.
+        loop = asyncio.new_event_loop()
+
+        async def _enter() -> None:
+            stack = await manager.get_stack(_provider)
+
+            async def _teardown() -> None:
+                teardown_ran["value"] = True
+                # Would hang/raise if run on the wrong loop; must never be invoked.
+                await asyncio.sleep(0)
+
+            stack.push_async_callback(_teardown)
+
+        loop.run_until_complete(_enter())
+        loop.close()
+        holder["loop"] = loop
+
+    thread = threading.Thread(target=_setup_then_close_loop)
+    thread.start()
+    thread.join(timeout=5)
+    assert holder["loop"].is_closed()
+
+    # Must complete promptly without awaiting the dead loop's teardown.
+    await asyncio.wait_for(manager.cleanup_all_stacks(raise_exception=True), timeout=10)
+
+    assert teardown_ran["value"] is False
+    # Registry is emptied regardless.
+    with suppress(Exception):
+        assert not list(manager._stacks)

--- a/test/test_pytest_plugin.py
+++ b/test/test_pytest_plugin.py
@@ -1,11 +1,14 @@
 from contextlib import AsyncExitStack
+from typing import Any
 from unittest.mock import Mock
+from weakref import WeakKeyDictionary
 
 import pytest
 
 from src.fastapi_injectable import pytest_plugin
 from src.fastapi_injectable.async_exit_stack import async_exit_stack_manager
 from src.fastapi_injectable.cache import dependency_cache
+from src.fastapi_injectable.concurrency import loop_manager
 
 
 def test_reset_injectable_state_clears_cache_and_stacks() -> None:
@@ -13,7 +16,10 @@ def test_reset_injectable_state_clears_cache_and_stacks() -> None:
         """A stand-in provider key for the exit-stack manager."""
 
     dependency_cache.get()[("leaked",)] = object()
-    async_exit_stack_manager._stacks[marker] = AsyncExitStack()
+    # Seed the per-loop registry under the loop reset() will run cleanup on.
+    per_loop: WeakKeyDictionary[Any, Any] = WeakKeyDictionary()
+    per_loop[marker] = AsyncExitStack()
+    async_exit_stack_manager._stacks[loop_manager.get_loop()] = per_loop
     assert dependency_cache.get()
     assert async_exit_stack_manager._stacks
 


### PR DESCRIPTION
## Summary

Follow-up to #186. The dependency **cache** half of #186 is tracked separately; this PR fixes the **exit-stack** half, an independent cross-loop defect in `AsyncExitStackManager`.

`_stacks` was keyed by provider function only — never by the event loop each async-generator dependency was *entered* on. Cleanup (`cleanup_stack` / `cleanup_all_stacks`) then dispatched `stack.aclose()` onto whatever loop `loop_manager` happened to yield, not the loop the teardown's loop-bound primitives belong to.

When a dependency's `finally:` awaits a loop-A-bound primitive (an `asyncio` `Future`/`Event`/`Lock`, an `httpx`/`anyio` connection pool, an `asyncpg` connection, …) and cleanup runs on loop B, `aclose()` either **hangs inside the library's own teardown path** (Python < 3.13, or behind a no-guard suspend point) or raises **`RuntimeError: ... attached to a different loop`** (3.13+). Reproduces on `main` with the pytest plugin on *and* off (e.g. under the `background_thread` loop strategy).

## Fix

Partition the registry by owning loop:

```
WeakKeyDictionary[loop -> WeakKeyDictionary[func -> AsyncExitStack]]
```

`get_stack` records a stack under the loop resolution runs on. Cleanup closes each stack **on its owning loop**:

- owner is the current running loop → `await stack.aclose()` directly;
- owner is alive and running in another thread → dispatch via `run_coroutine_threadsafe` and await the result without blocking this loop;
- owner loop is closed / no longer running → its async-gen resources are already dead; **drop** the stack instead of awaiting a teardown cross-loop (which would hang or raise).

### Lock redesign

The lock is now a `threading.Lock` guarding **only** the synchronous registry mutations. Every `await stack.aclose()` runs *outside* the lock (the stack is popped from the registry first), so the lock never spans an await — it can never block a loop and is safe across loops and free-threaded builds. (An `asyncio.Lock` would bind to the first loop that awaited it and reject the other concurrently-live loop that drives cross-loop cleanup.)

## Tests

- New `test/test_async_exit_stack_loop_partition.py`: cross-loop regression tests — teardown runs on its owning loop (alive-elsewhere → dispatched; current → direct), and a dead owner loop is dropped rather than awaited. These **fail on `main`** (`DependencyCleanupError` / teardown run on the wrong loop) and pass here.
- Rewrote `test/test_async_exit_stack.py`: the prior tests mocked `loop_manager` and assumed func-only keying; they now exercise real per-loop semantics.
- Updated one `test_pytest_plugin.py` seed to the per-loop registry shape.

## Verification

- `nox -s tests-3.13` → 214 passed; `tests-3.13t` → 205 passed, 2 skipped; 0 failures.
- `nox -s coverage` → 100% (`async_exit_stack.py` 94 stmts / 24 branches, 0 missing).
- `nox -s mypy` → clean on 3.10–3.14; `ruff` + `ruff-format` clean.