### PR TITLE
fix: partition InjectableScope cache by event loop (#186 follow-up)

### DIFF
--- a/src/fastapi_injectable/scope.py
+++ b/src/fastapi_injectable/scope.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+import asyncio
 import contextvars
+import threading
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import TYPE_CHECKING, Any
+from weakref import WeakKeyDictionary
+
+from .concurrency import loop_manager
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from types import TracebackType
 
     from typing_extensions import Self
+
+_Loop = asyncio.AbstractEventLoop
 
 _current_scope: contextvars.ContextVar[InjectableScope | None] = contextvars.ContextVar(
     "fastapi_injectable_current_scope", default=None
@@ -23,12 +30,42 @@ class InjectableScope:
     active routes its generator cleanup into this scope's exit stack and its
     cached values into this scope's cache. Leaving the scope closes the exit
     stack (running all cleanup) and drops the cache.
+
+    The cache is partitioned by event loop. A scope object reused across event
+    loops -- resolved on loop A then on loop B while both are alive -- must never
+    serve a loop-A resource to loop B: a cached value commonly holds a loop-bound
+    primitive (an ``asyncio`` future/lock, an ``httpx``/``anyio`` pool, an
+    ``asyncpg`` connection), and awaiting it on a different loop blocks forever or
+    raises "attached to a different loop". This mirrors the global dependency
+    cache fix behind https://github.com/JasperSui/fastapi-injectable/issues/186.
+    A scope used on a single loop caches exactly as before.
+
+    The exit stack is a single stack: its lifecycle is bounded by ``async with``
+    (or an explicit ``scope.exit_stack`` the caller manages), so it is always
+    closed on the same loop it was populated on. Partitioning it per loop would
+    break that explicit single-stack contract (e.g. resolving under
+    ``get_injected_obj(..., scope=scope)`` and then closing ``scope.exit_stack``
+    from sync code), so the stack stays whole.
     """
 
     def __init__(self, *, use_cache: bool = True) -> None:
         self._exit_stack = AsyncExitStack()
-        self._cache: dict[Any, Any] | None = {} if use_cache else None
+        self._use_cache = use_cache
+        # One cache dict per event loop, keyed weakly so a loop's cache disappears
+        # once the loop is gone. ``None`` semantics (caching disabled) are kept via
+        # the ``_use_cache`` flag rather than a nullable dict.
+        self._caches: WeakKeyDictionary[_Loop, dict[Any, Any]] = WeakKeyDictionary()
         self._token: contextvars.Token[InjectableScope | None] | None = None
+        # A plain threading.Lock guarding only the synchronous get-or-create of the
+        # per-loop cache below; it never spans an await.
+        self._lock = threading.Lock()
+
+    def _current_loop(self) -> _Loop:
+        """The loop whose cache this scope should use right now."""
+        try:
+            return asyncio.get_running_loop()
+        except RuntimeError:
+            return loop_manager.get_loop()
 
     @property
     def exit_stack(self) -> AsyncExitStack:
@@ -40,8 +77,16 @@ class InjectableScope:
         return self._exit_stack
 
     def get_cache(self) -> dict[Any, Any] | None:
-        """The scope's dependency cache (``None`` when caching is disabled)."""
-        return self._cache
+        """The scope's dependency cache for the current loop (``None`` when caching is disabled)."""
+        if not self._use_cache:
+            return None
+        loop = self._current_loop()
+        with self._lock:
+            cache = self._caches.get(loop)
+            if cache is None:
+                cache = {}
+                self._caches[loop] = cache
+            return cache
 
     async def __aenter__(self) -> Self:
         await self._exit_stack.__aenter__()

--- a/test/test_scope_loop_partition.py
+++ b/test/test_scope_loop_partition.py
@@ -1,0 +1,88 @@
+"""Regression test for cross-event-loop reuse of an InjectableScope (issue #186 follow-up B).
+
+An ``InjectableScope`` object held by the user and reused across event loops must not
+share a resolved resource between loops. Its cache is partitioned per loop, exactly
+like the global dependency cache: a resource resolved on loop A is never served to a
+different loop B. Doing so awaits a loop-A-bound primitive on loop B, which on Python
+3.13+ raises ``RuntimeError: ... attached to a different loop`` and on older runtimes
+hangs forever.
+"""
+
+import asyncio
+
+from fastapi_injectable.scope import InjectableScope
+from fastapi_injectable.util import async_get_injected_obj
+
+
+def test_explicit_scope_cache_is_isolated_per_event_loop() -> None:
+    """A scope reused across loops must not serve a loop-A resource to loop B."""
+    call_count = 0
+
+    class PooledResource:
+        def __init__(self) -> None:
+            # Capture the creation loop, exactly as real async clients do.
+            self._loop = asyncio.get_running_loop()
+
+        async def request(self) -> int:
+            # Drive work through the creation loop. If this instance is reused on a
+            # different loop, awaiting this future never completes there.
+            fut: asyncio.Future[int] = self._loop.create_future()
+            self._loop.call_soon(fut.set_result, 1)
+            return await fut
+
+    async def get_resource() -> PooledResource:
+        nonlocal call_count
+        call_count += 1
+        return PooledResource()
+
+    scope = InjectableScope()
+
+    async def scenario() -> int:
+        res = await async_get_injected_obj(get_resource, use_cache=True, scope=scope)
+        # Same loop + same scope: caching is preserved, the instance is reused.
+        res_again = await async_get_injected_obj(get_resource, use_cache=True, scope=scope)
+        assert res_again is res
+        return await res.request()
+
+    loop_a = asyncio.new_event_loop()
+    loop_b = asyncio.new_event_loop()
+    try:
+        assert loop_a.run_until_complete(scenario()) == 1
+        # loop_a is still OPEN; reusing the SAME scope on loop_b must resolve its own
+        # resource, not serve loop_a's (which would hang / raise cross-loop).
+        assert loop_b.run_until_complete(scenario()) == 1
+    finally:
+        loop_a.close()
+        loop_b.close()
+
+    # Two distinct loops -> two independent resolutions (no cross-loop sharing).
+    assert call_count == 2
+
+
+def test_explicit_scope_caches_per_loop_but_shares_within_a_loop() -> None:
+    """Within one loop a reused scope keeps caching; across loops it does not."""
+    call_count = 0
+
+    async def get_value() -> object:
+        nonlocal call_count
+        call_count += 1
+        return object()
+
+    scope = InjectableScope()
+
+    async def resolve_twice() -> bool:
+        first = await async_get_injected_obj(get_value, use_cache=True, scope=scope)
+        second = await async_get_injected_obj(get_value, use_cache=True, scope=scope)
+        return first is second
+
+    loop_a = asyncio.new_event_loop()
+    loop_b = asyncio.new_event_loop()
+    try:
+        assert loop_a.run_until_complete(resolve_twice()) is True  # cached within loop A
+        assert loop_b.run_until_complete(resolve_twice()) is True  # cached within loop B
+    finally:
+        loop_a.close()
+        loop_b.close()
+
+    # 2 resolutions total: one per loop (the second call on each loop is a cache hit).
+    assert call_count == 2


### PR DESCRIPTION
## Summary

Second follow-up to #186 (independent of the exit-stack-manager PR). `InjectableScope` kept a single `dict` cache, so a **user-held scope object reused across event loops** would serve a resource resolved on loop A to a still-open loop B on a cache hit — the same cross-loop reuse hang as the old global cache.

Cached values commonly hold a loop-bound primitive (an `asyncio` future/lock, an `httpx`/`anyio` connection pool, an `asyncpg` connection). Awaiting one on a different loop hangs forever, or on Python 3.13+ raises `RuntimeError: ... attached to a different loop`. The common `injectable_scope()` path (a fresh scope per `async with`) was never affected; the hazard is a manually-held scope used on more than one loop.

## Fix

Partition the scope's cache per loop, mirroring the global `DependencyCache` fix:

```
WeakKeyDictionary[loop -> dict]
```

`get_cache()` returns the current loop's cache dict (get-or-created under a `threading.Lock` that guards only the synchronous dict op and never spans an await). A scope used on a single loop caches exactly as before; reused across loops, each loop gets its own cache and never shares a resolved instance.

### Why the exit stack is intentionally *not* partitioned

The exit stack is left as a single `AsyncExitStack`. Its lifecycle is bounded by `async with` (or an explicit `scope.exit_stack` the caller manages), so it is always closed on the same loop it was populated on. Partitioning it per loop would break the supported single-stack contract — e.g. `get_injected_obj(..., scope=scope)` (sync) followed by closing `scope.exit_stack` from sync code, where the resolve-loop and close-loop are resolved via `loop_manager.get_loop()` at different times and need not be the same loop object. Verified empirically: a per-loop exit stack breaks `test_get_injected_obj_explicit_scope_sync` under pytest-asyncio's loop management. The cache is the documented cross-loop reuse hazard; the exit stack stays whole.

## Tests

New `test/test_scope_loop_partition.py`:
- `test_explicit_scope_cache_is_isolated_per_event_loop` — a reused scope serving a loop-A resource to loop B raises cross-loop on `main`; here each loop resolves its own.
- `test_explicit_scope_caches_per_loop_but_shares_within_a_loop` — within-loop caching is preserved; only the cross-loop sharing is removed.

Both fail on `main` (RuntimeError / `1 == 2`) and pass here.

## Verification

- `nox -s tests-3.13` → 210 passed; `tests-3.13t` → 201 passed, 2 skipped; 0 failures.
- `nox -s coverage` → 100% (`scope.py` 46 stmts / 6 branches, 0 missing).
- `nox -s mypy` → clean on 3.10–3.14; `ruff` + `ruff-format` clean.