### PR TITLE
bump: from 1.6.0 to 1.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi-injectable"
-version = "1.6.0"
+version = "1.6.1"
 description = "Use FastAPI's Depends() anywhere — in CLI tools, Celery tasks, background workers, and more. No refactoring needed."
 authors = [{ name = "Jasper Sui", email = "suiyang03@gmail.com" }]
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -520,7 +520,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-injectable"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Version bump from **1.6.0** to **1.6.1**.

A patch release: generator dependencies now receive the in-flight exception when the code using them fails, so `except` / rollback branches actually run — full parity with a failing FastAPI request. Two pre-existing bugs found while fixing it are included.

### Highlights since v1.6.0

**Fixes**
- `fix: unwind exit stacks with in-flight exception details so generator dependencies can roll back` (#259) — fixes #255. Exit stacks were always closed via `aclose()` (i.e. `__aexit__(None, None, None)`), so a generator dependency's `except:` / rollback branch could never run. Now:
  - inner FastAPI request-scope stacks (`fastapi_inner_astack` / `fastapi_function_astack`, used by fastapi>=0.121) are registered with `push_async_exit` instead of `push_async_callback(stack.aclose)`, so exception details reach the stacks where generator teardowns actually live;
  - `cleanup_exit_stack_of_func()` / `cleanup_all_exit_stacks()` take an optional `exc=`, unwinding via `__aexit__(type(exc), exc, exc.__traceback__)`. A dependency that re-raises the in-flight exception is treated as normal context-manager protocol, not a cleanup failure; genuinely distinct teardown failures still raise `DependencyCleanupError`;
  - `injectable_scope()` forwards the exception automatically — no extra plumbing at the call site.
- Sync-path **loop stickiness** (`concurrency.py`) — under the default `"current"` strategy, once the thread had no policy event loop set, every `run_coroutine_sync` created a fresh unregistered loop, so dependencies resolved on loop A while cleanup ran on loop B and the per-loop stack registry (#186) refused to close A's stacks, silently skipping generator teardown. The created loop is now registered via `asyncio.set_event_loop`, with a guard for closed policy loops.
- Latest-mypy failure (`util.py`) — `return value` inside the asyncgen loop now uses `cast("T2", value)`.

**Dependencies** — 7 dependabot bumps (#251, #252, #253, #254, #256, #257, #258); CI actions and dev-group packages only, no runtime dependency changes.

### Breaking changes

No API breaks — `exc=` is an optional keyword on existing functions. One intentional semantic change, matching FastAPI: when an exception is delivered to a generator dependency, code after a bare `yield` (no `try` / `finally`) no longer runs. Teardown that must always run belongs in `finally`.
